### PR TITLE
Fix for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: python
 
 matrix:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ Jean-Luc Starck <jl.stark@cea.fr>
 Philippe Ciuciu <philippe.ciuciu@cea.fr>
 """
 # Write setup
-setup_requires = ["numpy", "scipy", "cython", "pytest-runner", "scikit-image"]
+setup_requires = ["numpy", "cython", "pytest-runner", "scikit-image"]
 
 pip_main(['install'] + setup_requires)
 
@@ -49,6 +49,7 @@ setup(
     install_requires=["scikit-learn",
                       "progressbar2",
                       "joblib",
+                      "scipy<=1.3.3",
                       "psutil",
                       "pynfft@git+https://github.com/ghisvail/pyNFFT@master"],
     dependency_links=['https://github.com/ghisvail/pyNFFT/tarball/master#egg=pynfft-1.3.0'],


### PR DESCRIPTION
This PR holds:
1) Fixes for Travis to enable pynfft import to work right: https://github.com/scikit-learn/scikit-learn/issues/14485#issuecomment-522218682
2) Limit Scipy to 1.3.3 as 1.4 is breaking some things for wavelet UD tests for now. This must be fixed in Modopt as we leverage functions from Modopt. This fix here is a temporary workaround