### PR TITLE
Extend SelfCalibrationReconstructor smaps use, add getter and setter

### DIFF
--- a/mri/reconstructors/self_calibrating.py
+++ b/mri/reconstructors/self_calibrating.py
@@ -55,14 +55,21 @@ class SelfCalibrationReconstructor(ReconstructorBase):
         int or tuple indicating the k-space portion used to estimate the coil
         sensitivity information.
         if int, will be evaluated to (0.1,)*nb_dim of the image
+    Smaps: np.ndarray (optional, default None)
+        Sensivity maps used to initialize the gradient operator. If set to None,
+        the maps will have to be recomputed once when calling the reconstruct
+        method. The shape should correspond to the shape of the expected volume.
+        for gradient initialization:
+            Please refer to mri.operators.gradient.base for information
     smaps_extraction_mode: string 'FFT' | 'NFFT' | 'Stack' | 'gridding' default
         Defines the mode in which we would want to interpolate to extract the
-        sensitivity information,
+        sensitivity information when recomputing the sensivity maps.
         NOTE: FFT should be considered only if the input has
         been sampled on the grid
     smaps_gridding_method: string 'linear' (default) | 'cubic' | 'nearest'
         For gridding mode, it defines the way interpolation must be done used
-        by the sensitivity extraction method.
+        by the sensitivity extraction method when recomputing
+        the sensibity maps.
     n_jobs: int, default 1
         The number of CPUs used to accelerate the reconstruction
     verbose: int, optional default 0
@@ -83,7 +90,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
 
     def __init__(self, fourier_op, linear_op=None,
                  gradient_formulation="synthesis", kspace_portion=0.1,
-                 smaps_extraction_mode='gridding',
+                 Smaps=None, smaps_extraction_mode='gridding',
                  smaps_gridding_method='linear', n_jobs=1, verbose=0,
                  **kwargs):
         if linear_op is None:
@@ -95,6 +102,9 @@ class SelfCalibrationReconstructor(ReconstructorBase):
                 n_coils=1,
                 verbose=bool(verbose >= 30),
             )
+        # Add Smaps to kwargs if necessary for gradient initialization
+        if (not Smaps is None):
+            kwargs["Smaps"] = Smaps
         # Ensure that we are in right multichannel config
         if linear_op.n_coils != 1:
             raise ValueError("The value of n_coils for linear operation must "
@@ -108,7 +118,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
             linear_op=linear_op,
             gradient_formulation=gradient_formulation,
             grad_class=grad_class,
-            init_gradient_op=False,
+            init_gradient_op=(not Smaps is None),
             verbose=verbose,
             **kwargs,
         )
@@ -124,6 +134,30 @@ class SelfCalibrationReconstructor(ReconstructorBase):
                              "sensitivity information is not aligned with" +
                              " the input dimension")
         self.n_jobs = n_jobs
+
+    def get_smaps(self):
+        """ This method returns the sensivity maps.
+
+        Returns
+        -------
+        np.ndarray, None
+            The sensivity maps when given or already computed, or None.
+        """
+
+        return self.extra_grad_args.get("Smaps")
+
+    def set_smaps(self, Smaps):
+        """ This method sets the sensivity maps and re-initializes
+        the gradient operator accordingly.
+
+        Parameters
+        ----------
+        Smaps: np.ndarray
+            for gradient initialization:
+                Please refer to mri.operators.gradient.base for information
+        """
+        self.extra_grad_args["Smaps"] = Smaps
+        self.initialize_gradient_op(**self.extra_grad_args)
 
     def reconstruct(self, kspace_data, optimization_alg='pogm', x_init=None,
                     num_iterations=100, recompute_smaps=True, **kwargs):
@@ -170,8 +204,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
                 method=self.smaps_gridding_method,
                 n_cpu=self.n_jobs
             )
-            self.extra_grad_args['Smaps'] = Smaps
-            self.initialize_gradient_op(**self.extra_grad_args)
+            self.set_smaps(self, Smaps)
         # Start Reconstruction
         super(SelfCalibrationReconstructor, self).reconstruct(
             kspace_data,

--- a/mri/reconstructors/self_calibrating.py
+++ b/mri/reconstructors/self_calibrating.py
@@ -59,9 +59,10 @@ class SelfCalibrationReconstructor(ReconstructorBase):
         for gradient initialization:
             Please refer to mri.operators.gradient.base for information.
 
-        Sensivity maps used to initialize the gradient operator. If set to None,
-        the maps will have to be recomputed once when calling the reconstruct
-        method. The shape should correspond to the shape of the expected volume.
+        Sensivity maps used to initialize the gradient operator. If set to
+        None, the maps will have to be recomputed once when calling the
+        reconstruct method. The shape should correspond to the shape of
+        the expected volume.
     smaps_extraction_mode: string 'FFT' | 'NFFT' | 'Stack' | 'gridding' default
         Defines the mode in which we would want to interpolate to extract the
         sensitivity information when recomputing the sensivity maps.
@@ -104,7 +105,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
                 verbose=bool(verbose >= 30),
             )
         # Add Smaps to kwargs if necessary for gradient initialization
-        if (not Smaps is None):
+        if (Smaps is not None):
             kwargs["Smaps"] = Smaps
         # Ensure that we are in right multichannel config
         if linear_op.n_coils != 1:

--- a/mri/reconstructors/self_calibrating.py
+++ b/mri/reconstructors/self_calibrating.py
@@ -65,13 +65,13 @@ class SelfCalibrationReconstructor(ReconstructorBase):
         the expected volume.
     smaps_extraction_mode: string 'FFT' | 'NFFT' | 'Stack' | 'gridding' default
         Defines the mode in which we would want to interpolate to extract the
-        sensitivity information when recomputing the sensivity maps.
+        sensitivity information when recomputing the sensitivity maps.
         NOTE: FFT should be considered only if the input has
         been sampled on the grid
     smaps_gridding_method: string 'linear' (default) | 'cubic' | 'nearest'
         For gridding mode, it defines the way interpolation must be done used
         by the sensitivity extraction method when recomputing
-        the sensibity maps.
+        the sensitivity maps.
     n_jobs: int, default 1
         The number of CPUs used to accelerate the reconstruction.
     verbose: int, optional default 0
@@ -138,17 +138,17 @@ class SelfCalibrationReconstructor(ReconstructorBase):
         self.n_jobs = n_jobs
 
     def get_smaps(self):
-        """ This method returns the sensivity maps.
+        """ This method returns the sensitivity maps.
 
         Returns
         -------
         np.ndarray, None
-            The sensivity maps when given or already computed, or None.
+            The sensitivity maps when given or already computed, or None.
         """
         return self.extra_grad_args.get("Smaps")
 
     def set_smaps(self, Smaps):
-        """ This method sets the sensivity maps and re-initializes
+        """ This method sets the sensitivity maps and re-initializes
         the gradient operator accordingly.
 
         Parameters

--- a/mri/reconstructors/self_calibrating.py
+++ b/mri/reconstructors/self_calibrating.py
@@ -56,11 +56,12 @@ class SelfCalibrationReconstructor(ReconstructorBase):
         sensitivity information.
         if int, will be evaluated to (0.1,)*nb_dim of the image
     Smaps: np.ndarray (optional, default None)
+        for gradient initialization:
+            Please refer to mri.operators.gradient.base for information.
+
         Sensivity maps used to initialize the gradient operator. If set to None,
         the maps will have to be recomputed once when calling the reconstruct
         method. The shape should correspond to the shape of the expected volume.
-        for gradient initialization:
-            Please refer to mri.operators.gradient.base for information
     smaps_extraction_mode: string 'FFT' | 'NFFT' | 'Stack' | 'gridding' default
         Defines the mode in which we would want to interpolate to extract the
         sensitivity information when recomputing the sensivity maps.
@@ -71,7 +72,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
         by the sensitivity extraction method when recomputing
         the sensibity maps.
     n_jobs: int, default 1
-        The number of CPUs used to accelerate the reconstruction
+        The number of CPUs used to accelerate the reconstruction.
     verbose: int, optional default 0
         Verbosity levels
             1 => Print basic debug information
@@ -81,7 +82,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
             NOTE - High verbosity (>20) levels are computationally intensive.
     **kwargs: Extra keyword arguments
         for gradient initialization:
-            Please refer to mri.operators.gradient.base for information
+            Please refer to mri.operators.gradient.base for information.
         regularizer_op: operator, (optional default None)
             Defines the regularization operator for the regularization
             function H. If None, the  regularization chosen is Identity and
@@ -143,7 +144,6 @@ class SelfCalibrationReconstructor(ReconstructorBase):
         np.ndarray, None
             The sensivity maps when given or already computed, or None.
         """
-
         return self.extra_grad_args.get("Smaps")
 
     def set_smaps(self, Smaps):
@@ -204,7 +204,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
                 method=self.smaps_gridding_method,
                 n_cpu=self.n_jobs
             )
-            self.set_smaps(self, Smaps)
+            self.set_smaps(Smaps)
         # Start Reconstruction
         super(SelfCalibrationReconstructor, self).reconstruct(
             kspace_data,

--- a/mri/reconstructors/self_calibrating.py
+++ b/mri/reconstructors/self_calibrating.py
@@ -119,7 +119,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
             linear_op=linear_op,
             gradient_formulation=gradient_formulation,
             grad_class=grad_class,
-            init_gradient_op=(not Smaps is None),
+            init_gradient_op=(Smaps is not None),
             verbose=verbose,
             **kwargs,
         )


### PR DESCRIPTION
This fixes issue #77 by adding sensivity maps as an optional argument to `SelfCalibrationReconstructor` during initialization. It also adds a getter and a setter for those sensivity maps with the appropriate documentation, in order to retrieve more easily the maps after a long computation.

The capital letter of the `Smaps` argument was kept to be coherent with the gradient operator `Smaps` argument, and to avoid unexpected behaviors by for example giving `smaps` as regular argument and `Smaps` in kwargs during `SelfCalibrationReconstructor` initialization.