### PR TITLE
Gridding Stack, add interpolation in z

### DIFF
--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -149,6 +149,8 @@ def get_stacks_fourier(kspace_loc, volume_shape):
     sampled_stack_z_loc = np.unique(kspace_loc[:, 2])
 
     try:
+        # We use np.isclose rather than '==' as the actual z_loc comes
+        # from scanner binary file that has been limited to floats
         idx_mask_z = np.asarray([
             np.where(np.isclose(z_loc, full_stack_z_loc))[0][0]
             for z_loc in sampled_stack_z_loc

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -216,12 +216,12 @@ def gridded_inverse_fourier_transform_stack(kspace_data_sorted,
     """
     This function calculates the gridded Inverse fourier transform
     from Interpolated non-Cartesian data into a cartesian grid. However,
-    the IFFT is done similar to Stacked Fourier transform. 
-    We expect the kspace data to be limited to a grid on z, we calculate 
+    the IFFT is done similar to Stacked Fourier transform.
+    We expect the kspace data to be limited to a grid on z, we calculate
     the inverse fourier transform by-
     1) Grid data in each plane (for all points in a plane)
     2) Interpolate data along z, if we have undersampled data along z
-    3) Apply an IFFT on the 3D data that was gridded.    
+    3) Apply an IFFT on the 3D data that was gridded.
 
     Parameters
     ----------
@@ -257,7 +257,7 @@ def gridded_inverse_fourier_transform_stack(kspace_data_sorted,
             method=method,
             fill_value=0,
         )
-    # Check if we have undersampled in Z direction, in which case, 
+    # Check if we have undersampled in Z direction, in which case,
     # we need to interpolate values along z to get a good reconstruction.
     if len(idx_mask_z) < volume_shape[2]:
         # Interpolate along z direction

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -223,7 +223,7 @@ def gridded_inverse_fourier_transform_stack(kspace_data_sorted,
     the inverse fourier transform by-
     1) Grid data in each plane (for all points in a plane)
     2) Interpolate data along z, if we have undersampled data along z
-    3) Apply an IFFT on the 3D data that was gridded.
+    3) Apply an IFFT on the 3D data that was gridded and interpolated in z.
 
     Parameters
     ----------

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -150,7 +150,8 @@ def get_stacks_fourier(kspace_loc, volume_shape):
 
     try:
         idx_mask_z = np.asarray([
-            np.where(np.isclose(x, full_stack_z_loc))[0][0] for x in sampled_stack_z_loc
+            np.where(np.isclose(x, full_stack_z_loc))[0][0]
+            for x in sampled_stack_z_loc
         ])
     except IndexError:
         raise ValueError('The input must be a stack of 2D k-Space data')
@@ -254,7 +255,8 @@ def gridded_inverse_fourier_transform_stack(kspace_data_sorted,
     if len(idx_mask_z) < volume_shape[2]:
         # Interpolate along z direction
         grid_loc = [
-            np.linspace(-0.5, 0.5, volume_shape[i], endpoint=False) for i in range(3)
+            np.linspace(-0.5, 0.5, volume_shape[i], endpoint=False)
+            for i in range(3)
         ]
         interp_z = RegularGridInterpolator(
             (*grid_loc[0:2], grid_loc[2][idx_mask_z]),

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -18,7 +18,7 @@ import warnings
 # Third party import
 import numpy as np
 import scipy.fftpack as pfft
-from scipy.interpolate import griddata
+from scipy.interpolate import griddata, RegularGridInterpolator
 
 
 def convert_mask_to_locations(mask):
@@ -150,7 +150,7 @@ def get_stacks_fourier(kspace_loc, volume_shape):
 
     try:
         idx_mask_z = np.asarray([
-            np.where(x == full_stack_z_loc)[0][0] for x in sampled_stack_z_loc
+            np.where(np.isclose(x, full_stack_z_loc))[0][0] for x in sampled_stack_z_loc
         ])
     except IndexError:
         raise ValueError('The input must be a stack of 2D k-Space data')
@@ -250,6 +250,27 @@ def gridded_inverse_fourier_transform_stack(kspace_data_sorted,
             grid,
             method=method,
             fill_value=0,
+        )
+    if len(idx_mask_z) < volume_shape[2]:
+        # Interpolate along z direction
+        grid_loc = [
+            np.linspace(-0.5, 0.5, volume_shape[i], endpoint=False) for i in range(3)
+        ]
+        interp_z = RegularGridInterpolator(
+            (*grid_loc[0:2], grid_loc[2][idx_mask_z]),
+            gridded_kspace[:, :, idx_mask_z],
+            bounds_error=False,
+            fill_value=None,
+        )
+        unsampled_z = list(
+            set(np.arange(volume_shape[2])) - set(idx_mask_z)
+        )
+        mask = np.zeros(volume_shape)
+        mask[:, :, unsampled_z] = 1
+        loc = convert_mask_to_locations(mask)
+        gridded_kspace[:, :, unsampled_z] = np.reshape(
+            interp_z(loc),
+            (*volume_shape[0:2], len(unsampled_z)),
         )
     # Transpose every image in each slice
     return np.swapaxes(np.fft.fftshift(np.fft.ifftn(np.fft.ifftshift(

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -150,8 +150,8 @@ def get_stacks_fourier(kspace_loc, volume_shape):
 
     try:
         idx_mask_z = np.asarray([
-            np.where(np.isclose(x, full_stack_z_loc))[0][0]
-            for x in sampled_stack_z_loc
+            np.where(np.isclose(z_loc, full_stack_z_loc))[0][0]
+            for z_loc in sampled_stack_z_loc
         ])
     except IndexError:
         raise ValueError('The input must be a stack of 2D k-Space data')
@@ -216,7 +216,12 @@ def gridded_inverse_fourier_transform_stack(kspace_data_sorted,
     """
     This function calculates the gridded Inverse fourier transform
     from Interpolated non-Cartesian data into a cartesian grid. However,
-    the IFFT is done similar to Stacked Fourier transform.
+    the IFFT is done similar to Stacked Fourier transform. 
+    We expect the kspace data to be limited to a grid on z, we calculate 
+    the inverse fourier transform by-
+    1) Grid data in each plane (for all points in a plane)
+    2) Interpolate data along z, if we have undersampled data along z
+    3) Apply an IFFT on the 3D data that was gridded.    
 
     Parameters
     ----------
@@ -252,6 +257,8 @@ def gridded_inverse_fourier_transform_stack(kspace_data_sorted,
             method=method,
             fill_value=0,
         )
+    # Check if we have undersampled in Z direction, in which case, 
+    # we need to interpolate values along z to get a good reconstruction.
     if len(idx_mask_z) < volume_shape[2]:
         # Interpolate along z direction
         grid_loc = [


### PR DESCRIPTION
This resolves #81 

In this implementation, we have added checks to ensure that the kspace data is interpolated along z if we have undersampled in z, before actually carrying out IFFT.

This way, we are better approximating the kspace 3D gridding by 2D gridding and interpolation along z rather than simple zero filling.