### PR TITLE
Update OWL to avoid weights overflow with large volumes.

### DIFF
--- a/mri/operators/proximity/ordered_weighted_l1_norm.py
+++ b/mri/operators/proximity/ordered_weighted_l1_norm.py
@@ -77,7 +77,7 @@ class OWL(ProximityParent):
     @staticmethod
     def _oscar_weights(alpha, beta, size):
         """Here we parametrize weights based on alpha and beta"""
-        w = np.arange(size-1, -1, -1, dtype=np.float32)
+        w = np.arange(size-1, -1, -1, dtype=np.float64)
         w *= beta
         w += alpha
         return w


### PR DESCRIPTION
I encountered a problem with the OWL proximity operator as the size carried by the argument "band_shape" was too big in the case of my volume (32 channels, 384 Nx, 384 Ny, 208 Nz).
It was causing an overflow in the modified function, and raising later a ValueError because the weights were not ordered. Just changing dtype=float32 to dtype=float64 fixes the issue.