### PR TITLE
Fix Parallel wavelet run by having a queue of transformers

### DIFF
--- a/mri/tests/test_wavelet_adjoint.py
+++ b/mri/tests/test_wavelet_adjoint.py
@@ -43,8 +43,8 @@ class TestAdjointOperatorWaveletTransform(unittest.TestCase):
                     n_coils=ch,
                     n_jobs=2
                 )
-                Img = (np.random.randn(self.N, self.N) +
-                       1j * np.random.randn(self.N, self.N))
+                Img = np.squeeze(np.random.randn(ch, self.N, self.N) +
+                                 1j * np.random.randn(ch, self.N, self.N))
                 f_p = wavelet_op_adj.op(Img)
                 f = (np.random.randn(*f_p.shape) +
                      1j * np.random.randn(*f_p.shape))
@@ -95,8 +95,10 @@ class TestAdjointOperatorWaveletTransform(unittest.TestCase):
                     n_coils=ch,
                     n_jobs=-1,
                 )
-                Img = np.squeeze(np.random.randn(ch, self.N, self.N, self.N) +
-                       1j * np.random.randn(ch, self.N, self.N, self.N))
+                Img = np.squeeze(
+                    np.random.randn(ch, self.N, self.N, self.N) +
+                    1j * np.random.randn(ch, self.N, self.N, self.N)
+                )
                 f_p = wavelet_op_adj.op(Img)
                 f = (np.random.randn(*f_p.shape) +
                      1j * np.random.randn(*f_p.shape))

--- a/mri/tests/test_wavelet_adjoint.py
+++ b/mri/tests/test_wavelet_adjoint.py
@@ -28,100 +28,106 @@ class TestAdjointOperatorWaveletTransform(unittest.TestCase):
         """
         self.N = 64
         self.max_iter = 10
-        self.num_channels = 10
+        self.num_channels = [1, 10]
 
     def test_Wavelet2D_ISAP(self):
         """Test the adjoint operator for the 2D Wavelet transform
         """
-        for i in range(self.max_iter):
-            print("Process Wavelet2D_ISAP test '{0}'...", i)
-            wavelet_op_adj = WaveletN(wavelet_name="HaarWaveletTransform",
-                                      nb_scale=4)
-            Img = (np.random.randn(self.N, self.N) +
-                   1j * np.random.randn(self.N, self.N))
-            f_p = wavelet_op_adj.op(Img)
-            f = (np.random.randn(*f_p.shape) +
-                 1j * np.random.randn(*f_p.shape))
-            I_p = wavelet_op_adj.adj_op(f)
-            x_d = np.vdot(Img, I_p)
-            x_ad = np.vdot(f_p, f)
-            np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
+        for ch in self.num_channels:
+            print("Testing with Num Channels : " + str(ch))
+            for i in range(self.max_iter):
+                print("Process Wavelet2D_ISAP test '{0}'...", i)
+                wavelet_op_adj = WaveletN(
+                    wavelet_name="HaarWaveletTransform",
+                    nb_scale=4,
+                    n_coils=ch,
+                    n_jobs=2
+                )
+                Img = (np.random.randn(self.N, self.N) +
+                       1j * np.random.randn(self.N, self.N))
+                f_p = wavelet_op_adj.op(Img)
+                f = (np.random.randn(*f_p.shape) +
+                     1j * np.random.randn(*f_p.shape))
+                I_p = wavelet_op_adj.adj_op(f)
+                x_d = np.vdot(Img, I_p)
+                x_ad = np.vdot(f_p, f)
+                np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
         print(" Wavelet2 adjoint test passes")
 
     def test_Wavelet2D_PyWt(self):
         """Test the adjoint operator for the 2D Wavelet transform
         """
-        for i in range(self.max_iter):
-            print("Process Wavelet2D PyWt test '{0}'...", i)
-            wavelet_op_adj = WaveletN(wavelet_name="sym8",
-                                      nb_scale=4)
-            Img = (np.random.randn(self.N, self.N) +
-                   1j * np.random.randn(self.N, self.N))
-            f_p = wavelet_op_adj.op(Img)
-            f = (np.random.randn(*f_p.shape) +
-                 1j * np.random.randn(*f_p.shape))
-            I_p = wavelet_op_adj.adj_op(f)
-            x_d = np.vdot(Img, I_p)
-            x_ad = np.vdot(f_p, f)
-            np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
+        for ch in self.num_channels:
+            print("Testing with Num Channels : " + str(ch))
+            for i in range(self.max_iter):
+                print("Process Wavelet2D PyWt test '{0}'...", i)
+                wavelet_op_adj = WaveletN(
+                    wavelet_name="sym8",
+                    nb_scale=4,
+                    n_coils=ch,
+                    n_jobs=2
+                )
+                Img = np.squeeze(
+                    np.random.randn(ch, self.N, self.N) +
+                    1j * np.random.randn(ch, self.N, self.N)
+                )
+                f_p = wavelet_op_adj.op(Img)
+                f = (np.random.randn(*f_p.shape) +
+                     1j * np.random.randn(*f_p.shape))
+                I_p = wavelet_op_adj.adj_op(f)
+                x_d = np.vdot(Img, I_p)
+                x_ad = np.vdot(f_p, f)
+                np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
         print(" Wavelet2 adjoint test passes")
 
     def test_Wavelet3D_PyWt(self):
         """Test the adjoint operator for the 3D Wavelet transform
         """
-        for i in range(self.max_iter):
-            print("Process Wavelet3D PyWt test '{0}'...", i)
-            wavelet_op_adj = WaveletN(wavelet_name="sym8",
-                                      nb_scale=4, dim=3,
-                                      padding_mode='periodization')
-            Img = (np.random.randn(self.N, self.N, self.N) +
-                   1j * np.random.randn(self.N, self.N, self.N))
-            f_p = wavelet_op_adj.op(Img)
-            f = (np.random.randn(*f_p.shape) +
-                 1j * np.random.randn(*f_p.shape))
-            I_p = wavelet_op_adj.adj_op(f)
-            x_d = np.vdot(Img, I_p)
-            x_ad = np.vdot(f_p, f)
-            np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
+        for ch in self.num_channels:
+            print("Testing with Num Channels : " + str(ch))
+            for i in range(self.max_iter):
+                print("Process Wavelet3D PyWt test '{0}'...", i)
+                wavelet_op_adj = WaveletN(
+                    wavelet_name="sym8",
+                    nb_scale=4,
+                    dim=3,
+                    padding_mode='periodization',
+                    n_coils=ch,
+                    n_jobs=-1,
+                )
+                Img = np.squeeze(np.random.randn(ch, self.N, self.N, self.N) +
+                       1j * np.random.randn(ch, self.N, self.N, self.N))
+                f_p = wavelet_op_adj.op(Img)
+                f = (np.random.randn(*f_p.shape) +
+                     1j * np.random.randn(*f_p.shape))
+                I_p = wavelet_op_adj.adj_op(f)
+                x_d = np.vdot(Img, I_p)
+                x_ad = np.vdot(f_p, f)
+                np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
         print(" Wavelet3 adjoint test passes")
 
     def test_Wavelet_UD_2D(self):
         """Test the adjoint operation for Undecimated wavelet
         """
-        for i in range(self.max_iter):
-            print("Process Wavelet Undecimated test '{0}'...", i)
-            wavelet_op = WaveletUD2(nb_scale=4)
-            img = (np.random.randn(self.N, self.N) +
-                   1j * np.random.randn(self.N, self.N))
-            f_p = wavelet_op.op(img)
-            f = (np.random.randn(*f_p.shape) +
-                 1j * np.random.randn(*f_p.shape))
-            i_p = wavelet_op.adj_op(f)
-            x_d = np.vdot(img, i_p)
-            x_ad = np.vdot(f_p, f)
-            np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
+        for ch in self.num_channels:
+            print("Testing with Num Channels : " + str(ch))
+            for i in range(self.max_iter):
+                print("Process Wavelet Undecimated test '{0}'...", i)
+                wavelet_op = WaveletUD2(
+                    nb_scale=4,
+                    n_coils=ch,
+                    n_jobs=2,
+                )
+                img = np.squeeze(np.random.randn(ch, self.N, self.N) +
+                                 1j * np.random.randn(ch, self.N, self.N))
+                f_p = wavelet_op.op(img)
+                f = (np.random.randn(*f_p.shape) +
+                     1j * np.random.randn(*f_p.shape))
+                i_p = wavelet_op.adj_op(f)
+                x_d = np.vdot(img, i_p)
+                x_ad = np.vdot(f_p, f)
+                np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
         print("Undecimated Wavelet 2D adjoint test passes")
-
-    def test_Wavelet_UD_2D_Multichannel(self):
-        """Test the adjoint operation for Undecmated wavelet Transform in
-        multichannel case"""
-        for i in range(self.max_iter):
-            print("Process Wavelet Undecimated test '{0}'...", i)
-            wavelet_op = WaveletUD2(
-                nb_scale=4,
-                n_coils=self.num_channels,
-                n_jobs=2
-            )
-            img = (np.random.randn(self.num_channels, self.N, self.N) +
-                   1j * np.random.randn(self.num_channels, self.N, self.N))
-            f_p = wavelet_op.op(img)
-            f = (np.random.randn(*f_p.shape) +
-                 1j * np.random.randn(*f_p.shape))
-            i_p = wavelet_op.adj_op(f)
-            x_d = np.vdot(img, i_p)
-            x_ad = np.vdot(f_p, f)
-            np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
-        print("Undecimated Wavelet 2D adjoint test passes for multichannel")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR resolves #104 

1) I have basically implemented a wavelet queue which is used when `n_jobs != 1` 
2) It looks like we have `get_coeff` and `set_coeff` functions in WaveletN, but we never used them, this seems to be stale, removing them to keep code simple
3) Also, I have updated the tests to ensure we dont miss such bugs in future. I have refactored some tests to ensure there is no redundancy when it comes to testing multichannel or single channel

Adding @Daval-G for testing the codes with calibration less reconstruction
Adding @zaccharieramzi for final sign off on code structure and any issues with documentation (although there are no major changes)