### PR TITLE
Fix travis based on new pysap flow and add support to python3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install --upgrade git+https://github.com/cea-cosmic/pysap
+            pip install git+https://github.com/cea-cosmic/pysap
             pip install -r doc/requirements.txt
             pip list > doc/state.txt
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pushd ../
-            git clone https://github.com/CEA-COSMIC/pysap
-            cd pysap
-            python setup.py install
-            echo "export PATH=$PATH:$PWD/build/temp.linux-x86_64-3.6/extern/bin" >> $BASH_ENV
-            popd
+            pip install git+https://github.com/cea-cosmic/pysap
             pip install -r doc/requirements.txt
             pip list > doc/state.txt
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --upgrade pip
-            pip install git+https://github.com/cea-cosmic/pysap
+            pip install --upgrade git+https://github.com/cea-cosmic/pysap
             pip install -r doc/requirements.txt
             pip list > doc/state.txt
       - save_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ install:
     - pip install --upgrade pip
     - pip install coverage nose pytest pytest-cov coveralls pycodestyle
     - pip install git+https://github.com/CEA-COSMIC/ModOpt.git
+    - pip install git+https://github.com/AGrigis/pysphinxdoc.git
+    - pip install sphinx==2.2.1
     - pip install git+https://github.com/CEA-COSMIC/pysap.git
     - export PYTHONPATH=$TRAVIS_BUILD_DIR/install:$PYTHONPATH
     - pip install -b $TRAVIS_BUILD_DIR/build -t $TRAVIS_BUILD_DIR/install --no-clean --upgrade .

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
         - python: 3.5
         - python: 3.6
         - python: 3.7
+        - python: 3.8
           dist: xenial
           sudo: true
 
@@ -14,14 +15,8 @@ before_install:
     - sudo apt-get update
     - sudo updatedb
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    - if [ $TRAVIS_PYTHON_VERSION == "3.5" ]; then
-        export CPLUS_INCLUDE_PATH=/opt/python/3.5.6/include/python3.5m;
-      fi
-    - if [ $TRAVIS_PYTHON_VERSION == "3.6" ]; then
-        export CPLUS_INCLUDE_PATH=/opt/python/3.6.3/include/python3.6m;
-      fi
-    - if [ $TRAVIS_PYTHON_VERSION == "3.7" ]; then
-        export CPLUS_INCLUDE_PATH=/opt/python/3.7.1/include/python3.7m;
+    - if [ $TRAVIS_OS_NAME = 'linux' ]; then
+        export CPLUS_INCLUDE_PATH=$(cd /opt/python/3.*/include/python3.*; pwd);
       fi
     - chmod +x miniconda.sh
     - ./miniconda.sh -b -p $HOME/miniconda
@@ -40,28 +35,9 @@ install:
     - ln -s $HOME/.local/share/pysap/pysap-data/pysap-data/* $HOME/.local/share/pysap
     - ls -l $HOME/.local/share/pysap
     - pip install --upgrade pip
-    - pip install matplotlib
-    - pip install coverage nose pytest pytest-cov
-    - pip install coveralls
-    - pip install pycodestyle
-    - pip install pybind11 nibabel pyqt5 pyqtgraph astropy 
+    - pip install coverage nose pytest pytest-cov coveralls pycodestyle
     - pip install git+https://github.com/CEA-COSMIC/ModOpt.git
-    - pip install git+https://github.com/AGrigis/pysphinxdoc.git
-    - pip install sphinx==2.2.1
-    - pushd ../
-    - git clone https://github.com/CEA-COSMIC/pysap
-    - cd pysap
-    - python setup.py install
-    - if [ $TRAVIS_PYTHON_VERSION == "3.5" ]; then
-        export PATH=$PATH:$PWD/build/temp.linux-x86_64-3.5/extern/bin;
-      fi
-    - if [ $TRAVIS_PYTHON_VERSION == "3.6" ]; then
-        export PATH=$PATH:$PWD/build/temp.linux-x86_64-3.6/extern/bin;
-      fi
-    - if [ $TRAVIS_PYTHON_VERSION == "3.7" ]; then
-        export PATH=$PATH:$PWD/build/temp.linux-x86_64-3.7/extern/bin;
-      fi
-    - popd
+    - pip install git+https://github.com/chaithyagr/pysap@fix_installs
     - export PYTHONPATH=$TRAVIS_BUILD_DIR/install:$PYTHONPATH
     - pip install -b $TRAVIS_BUILD_DIR/build -t $TRAVIS_BUILD_DIR/install --no-clean --upgrade .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: xenial
 language: python
-
+cache: pip
 matrix:
     include:
         - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
     - pip install --upgrade pip
     - pip install coverage nose pytest pytest-cov coveralls pycodestyle
     - pip install git+https://github.com/CEA-COSMIC/ModOpt.git
-    - pip install git+https://github.com/chaithyagr/pysap@fix_installs
+    - pip install git+https://github.com/CEA-COSMIC/pysap.git
     - export PYTHONPATH=$TRAVIS_BUILD_DIR/install:$PYTHONPATH
     - pip install -b $TRAVIS_BUILD_DIR/build -t $TRAVIS_BUILD_DIR/install --no-clean --upgrade .
 

--- a/examples/gridsearch_launch.py
+++ b/examples/gridsearch_launch.py
@@ -8,7 +8,7 @@ In this tutorial we will use the pysap-mri's launch grid helper function
 to carry out grid search. We will search for best regularisation weight
 and the best wavelet for reconstruction.
 For this the search space works on :
-mu          ==> 5 Values on log scale between 1e-8 and 1e-9
+mu          ==> 5 Values on log scale between 1e-8 and 1e-6
 Wavelets    ==> sym8 and sym12
 nb_scale    ==> 3 and 4
 """

--- a/mri/info.py
+++ b/mri/info.py
@@ -10,7 +10,7 @@
 # Module current version
 version_major = 0
 version_minor = 2
-version_micro = 0
+version_micro = 2
 
 # Expected by setup.py: string of form "X.Y.Z"
 __version__ = "{0}.{1}.{2}".format(version_major, version_minor, version_micro)

--- a/mri/operators/linear/wavelet.py
+++ b/mri/operators/linear/wavelet.py
@@ -67,7 +67,7 @@ class WaveletN(OperatorBase):
         if n_proc < 0:
             n_proc = joblib.cpu_count() + self.n_jobs + 1
         # Create transform queue for parallel execution
-        for i in range(min(n_proc, self.n_coils)):
+        for i in range(min(n_proc, self.n_coils)+1):
             self.transform_queue.append(transform_klass(
                 nb_scale=self.nb_scale,
                 verbose=verbose,

--- a/mri/operators/linear/wavelet.py
+++ b/mri/operators/linear/wavelet.py
@@ -18,11 +18,13 @@ from modopt.signal.wavelet import get_mr_filters, filter_convolve
 import pysap
 from pysap.base.utils import flatten
 from pysap.base.utils import unflatten
+from pysap.utils import wavelist
 
 # Third party import
 import joblib
 from joblib import Parallel, delayed
 import numpy as np
+import warnings
 
 
 class WaveletN(OperatorBase):
@@ -66,8 +68,13 @@ class WaveletN(OperatorBase):
         n_proc = self.n_jobs
         if n_proc < 0:
             n_proc = joblib.cpu_count() + self.n_jobs + 1
+        if n_proc > 0:
+            if wavelet_name in wavelist()['isap-2d'] or wavelet_name in wavelist()['isap-3d']:
+                warnings.warn("n_jobs is currently unsupported for ISAP wavelets, setting n_jobs=1")
+                self.n_jobs = 1
+                n_proc = 1
         # Create transform queue for parallel execution
-        for i in range(min(n_proc, self.n_coils)+1):
+        for i in range(min(n_proc, self.n_coils)):
             self.transform_queue.append(transform_klass(
                 nb_scale=self.nb_scale,
                 verbose=verbose,

--- a/mri/operators/linear/wavelet.py
+++ b/mri/operators/linear/wavelet.py
@@ -69,8 +69,10 @@ class WaveletN(OperatorBase):
         if n_proc < 0:
             n_proc = joblib.cpu_count() + self.n_jobs + 1
         if n_proc > 0:
-            if wavelet_name in wavelist()['isap-2d'] or wavelet_name in wavelist()['isap-3d']:
-                warnings.warn("n_jobs is currently unsupported for ISAP wavelets, setting n_jobs=1")
+            if wavelet_name in wavelist()['isap-2d'] or \
+                    wavelet_name in wavelist()['isap-3d']:
+                warnings.warn("n_jobs is currently unsupported "
+                              "for ISAP wavelets, setting n_jobs=1")
                 self.n_jobs = 1
                 n_proc = 1
         # Create transform queue for parallel execution

--- a/mri/optimizers/forward_backward.py
+++ b/mri/optimizers/forward_backward.py
@@ -63,7 +63,7 @@ def fista(gradient_op, linear_op, prox_op, cost_op,
     metrics: dict
         the requested metrics values during the optimization.
     """
-    start = time.clock()
+    start = time.perf_counter()
 
     # Define the initial primal and dual solutions
     if x_init is None:
@@ -111,7 +111,7 @@ def fista(gradient_op, linear_op, prox_op, cost_op,
     if verbose > 0:
         print("Starting optimization...")
     opt.iterate(max_iter=max_nb_of_iter)
-    end = time.clock()
+    end = time.perf_counter()
     if verbose > 0:
         # cost_op.plot_cost()
         if hasattr(cost_op, "cost"):
@@ -170,7 +170,7 @@ def pogm(gradient_op, linear_op, prox_op, cost_op=None,
     metrics: dict
         the requested metrics values during the optimization.
     """
-    start = time.clock()
+    start = time.perf_counter()
 
     # Define the initial values
     im_shape = (gradient_op.linear_op.n_coils, *gradient_op.fourier_op.shape)
@@ -214,7 +214,7 @@ def pogm(gradient_op, linear_op, prox_op, cost_op=None,
     if verbose > 0:
         print("Starting optimization...")
     opt.iterate(max_iter=max_nb_of_iter)
-    end = time.clock()
+    end = time.perf_counter()
     if verbose > 0:
         # cost_op.plot_cost()
         if hasattr(cost_op, "cost"):

--- a/mri/optimizers/primal_dual.py
+++ b/mri/optimizers/primal_dual.py
@@ -87,7 +87,7 @@ def condatvu(gradient_op, linear_op, dual_regularizer, cost_op,
         the estimated dual CONDAT-VU solution
     """
     # Check inputs
-    start = time.clock()
+    start = time.perf_counter()
     if std_est_method not in (None, "primal", "dual"):
         raise ValueError(
             "Unrecognize std estimation method '{0}'.".format(std_est_method))
@@ -206,7 +206,7 @@ def condatvu(gradient_op, linear_op, dual_regularizer, cost_op,
         opt.iterate(max_iter=max_nb_of_iter)
 
     # Goodbye message
-    end = time.clock()
+    end = time.perf_counter()
     if verbose > 0:
         if hasattr(cost_op, "cost"):
             print(" - final iteration number: ", cost_op._iteration)

--- a/mri/tests/test_wavelet_adjoint.py
+++ b/mri/tests/test_wavelet_adjoint.py
@@ -51,7 +51,7 @@ class TestAdjointOperatorWaveletTransform(unittest.TestCase):
                 I_p = wavelet_op_adj.adj_op(f)
                 x_d = np.vdot(Img, I_p)
                 x_ad = np.vdot(f_p, f)
-                np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
+                np.testing.assert_allclose(x_d, x_ad, rtol=1e-5)
         print(" Wavelet2 adjoint test passes")
 
     def test_Wavelet2D_PyWt(self):
@@ -77,7 +77,7 @@ class TestAdjointOperatorWaveletTransform(unittest.TestCase):
                 I_p = wavelet_op_adj.adj_op(f)
                 x_d = np.vdot(Img, I_p)
                 x_ad = np.vdot(f_p, f)
-                np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
+                np.testing.assert_allclose(x_d, x_ad, rtol=1e-5)
         print(" Wavelet2 adjoint test passes")
 
     def test_Wavelet3D_PyWt(self):
@@ -105,7 +105,7 @@ class TestAdjointOperatorWaveletTransform(unittest.TestCase):
                 I_p = wavelet_op_adj.adj_op(f)
                 x_d = np.vdot(Img, I_p)
                 x_ad = np.vdot(f_p, f)
-                np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
+                np.testing.assert_allclose(x_d, x_ad, rtol=1e-5)
         print(" Wavelet3 adjoint test passes")
 
     def test_Wavelet_UD_2D(self):
@@ -128,7 +128,7 @@ class TestAdjointOperatorWaveletTransform(unittest.TestCase):
                 i_p = wavelet_op.adj_op(f)
                 x_d = np.vdot(img, i_p)
                 x_ad = np.vdot(f_p, f)
-                np.testing.assert_allclose(x_d, x_ad, rtol=1e-6)
+                np.testing.assert_allclose(x_d, x_ad, rtol=1e-5)
         print("Undecimated Wavelet 2D adjoint test passes")
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ Jean-Luc Starck <jl.stark@cea.fr>
 Philippe Ciuciu <philippe.ciuciu@cea.fr>
 """
 # Write setup
-setup_requires = ["numpy", "cython", "pytest-runner", "scikit-image"]
+setup_requires = ["numpy>=1.16.4", "cython>=0.27.3"]
 
 pip_main(['install'] + setup_requires)
 
@@ -42,17 +42,19 @@ setup(
     classifiers="CLASSIFIERS",
     author=AUTHOR,
     author_email="XXX",
-    version="0.1.1",
+    version="0.2.0",
     url="https://github.com/CEA-COSMIC/pysap-mri",
     packages=find_packages(),
     setup_requires=setup_requires,
-    install_requires=["scikit-learn",
-                      "progressbar2",
-                      "joblib",
-                      "scipy<=1.3.3",
-                      "psutil",
-                      "pynfft@git+https://github.com/ghisvail/pyNFFT@master"],
+    install_requires=[
+        "scikit-learn>=0.19.1",
+        "progressbar2>=3.34.3",
+        "joblib",
+        "scipy>=1.3.0",
+        "pynfft",
+        "scikit-image",
+    ],
     dependency_links=['https://github.com/ghisvail/pyNFFT/tarball/master#egg=pynfft-1.3.0'],
-    tests_require=['pytest>=5.0.1', 'pytest-cov>=2.7.1', 'pytest-pep8'],
+    tests_require=['pytest>=5.0.1', 'pytest-cov>=2.7.1', 'pytest-pep8', 'pytest-runner'],
     platforms="OS Independent"
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     classifiers="CLASSIFIERS",
     author=AUTHOR,
     author_email="XXX",
-    version="0.2.0",
+    version="0.2.2",
     url="https://github.com/CEA-COSMIC/pysap-mri",
     packages=find_packages(),
     setup_requires=setup_requires,
@@ -51,10 +51,9 @@ setup(
         "progressbar2>=3.34.3",
         "joblib",
         "scipy>=1.3.0",
-        "pynfft",
+        "pynfft2>=1.3.3",
         "scikit-image",
     ],
-    dependency_links=['https://github.com/ghisvail/pyNFFT/tarball/master#egg=pynfft-1.3.0'],
     tests_require=['pytest>=5.0.1', 'pytest-cov>=2.7.1', 'pytest-pep8', 'pytest-runner'],
     platforms="OS Independent"
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ Jean-Luc Starck <jl.stark@cea.fr>
 Philippe Ciuciu <philippe.ciuciu@cea.fr>
 """
 # Write setup
-setup_requires = ["numpy>=1.16.4", "cython>=0.27.3"]
+setup_requires = ["numpy>=1.16.4", "cython>=0.27.3", "pytest-runner"]
 
 pip_main(['install'] + setup_requires)
 


### PR DESCRIPTION
1) With recent PR, we no longer need to add the binary file location (/extern/bin etc) to $PATH. This saves a lot of time and thus, pysap can be installed directly with pip install.

2) Also, added dependency to an internal released pynfft2 as the original pynfft was not released for quite some time and we would like to proceed with a release and not wait on them

3) Add python 3.8 for testing and overall move to testing on xenial as that corresponds to a higher ubuntu. Move `time.clock()` calls to `time.perf_counter()` calls to support python3.8

4) Remove support for n_jobs in ISAP wavelets due to erratic behavior.

5) Add a minute single documentation fix for #102. This resolves #102 

Will open the PR for review once I have passing travis
