### PR TITLE
Add support for density compensation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Special Installations
 
 For faster NUFFT operation, pysap-mri uses gpuNUFFT, to run the NUFFT on GPU. To install gpuNUFFT, please use:
 
-``pip install git+https://github.com/andyschwarzl/gpuNUFFT``
+``pip install gpuNUFFT``
 
 We are still in the process of merging this and getting a pip release for gpuNUFFT. Note, that you can still use CPU
 NFFT without installing the package.

--- a/examples/GPU_Examples/NonCartesian_gpuNUFFT_DensityCompensation.py
+++ b/examples/GPU_Examples/NonCartesian_gpuNUFFT_DensityCompensation.py
@@ -1,0 +1,71 @@
+"""
+Neuroimaging non-cartesian reconstruction
+=========================================
+
+Author: Chaithya G R
+
+In this tutorial we will reconstruct an MRI directly with density compensation
+
+Import neuroimaging data
+------------------------
+
+We use the toy datasets available in pysap, more specifically a 2D brain slice
+and the acquisition radial non-cartesian scheme.
+"""
+
+# Package import
+from mri.operators import NonCartesianFFT, WaveletUD2
+from mri.operators.utils import convert_locations_to_mask, \
+    gridded_inverse_fourier_transform_nd
+from mri.operators.fourier.utils import estimate_density_compensation
+from mri.reconstructors import SingleChannelReconstructor
+import pysap
+from pysap.data import get_sample_data
+
+# Third party import
+from modopt.math.metrics import ssim
+from modopt.opt.linear import Identity
+from modopt.opt.proximity import SparseThreshold
+import numpy as np
+
+# Loading input data
+image = get_sample_data('2d-mri')
+
+# Obtain MRI non-cartesian mask
+radial_mask = get_sample_data("mri-radial-samples")
+kspace_loc = radial_mask.data
+density_comp = estimate_density_compensation(kspace_loc, image.shape)
+
+#############################################################################
+# Generate the kspace
+# -------------------
+#
+# From the 2D brain slice and the acquisition mask, we retrospectively
+# undersample the k-space using a radial acquisition mask
+# We then reconstruct using adjoint with and without density compensation
+
+# Get the locations of the kspace samples and the associated observations
+fourier_op = NonCartesianFFT(
+    samples=kspace_loc,
+    shape=image.shape,
+    implementation='gpuNUFFT',
+)
+fourier_op_density_comp = NonCartesianFFT(
+    samples=kspace_loc,
+    shape=image.shape,
+    implementation='gpuNUFFT',
+    density_comp=density_comp
+)
+kspace_obs = fourier_op.op(image.data)
+
+# Simple adjoint
+image_rec0 = pysap.Image(data=np.abs(fourier_op.adj_op(kspace_obs)))
+# image_rec0.show()
+base_ssim = ssim(image_rec0, image)
+print('The SSIM from Adjoint is : ' + str(base_ssim))
+
+# Density Compensation adjoint
+image_rec1 = pysap.Image(data=np.abs(fourier_op_density_comp.adj_op(kspace_obs)))
+# image_rec1.show()
+new_ssim = ssim(image_rec1, image)
+print('The SSIM from Density compensated Adjoint is : ' + str(new_ssim))

--- a/examples/GPU_Examples/NonCartesian_gpuNUFFT_DensityCompensation.py
+++ b/examples/GPU_Examples/NonCartesian_gpuNUFFT_DensityCompensation.py
@@ -65,7 +65,10 @@ base_ssim = ssim(image_rec0, image)
 print('The SSIM from Adjoint is : ' + str(base_ssim))
 
 # Density Compensation adjoint
-image_rec1 = pysap.Image(data=np.abs(fourier_op_density_comp.adj_op(kspace_obs)))
+image_rec1 = pysap.Image(data=np.abs(
+    fourier_op_density_comp.adj_op(kspace_obs))
+)
 # image_rec1.show()
 new_ssim = ssim(image_rec1, image)
-print('The SSIM from Density compensated Adjoint is : ' + str(new_ssim))
+print('The SSIM from Density '
+      'compensated Adjoint is : ' + str(new_ssim))

--- a/examples/GPU_Examples/NonCartesian_gpuNUFFT_DensityCompensation.py
+++ b/examples/GPU_Examples/NonCartesian_gpuNUFFT_DensityCompensation.py
@@ -4,13 +4,14 @@ Neuroimaging non-cartesian reconstruction
 
 Author: Chaithya G R
 
-In this tutorial we will reconstruct an MRI directly with density compensation
+In this tutorial we will reconstruct an MR Image directly with density
+compensation
 
 Import neuroimaging data
 ------------------------
 
 We use the toy datasets available in pysap, more specifically a 2D brain slice
-and the acquisition radial non-cartesian scheme.
+and the radial acquisition scheme (non-cartesian).
 """
 
 # Package import
@@ -31,7 +32,7 @@ import numpy as np
 # Loading input data
 image = get_sample_data('2d-mri')
 
-# Obtain MRI non-cartesian mask
+# Obtain MRI non-cartesian mask and estimate the density compensation
 radial_mask = get_sample_data("mri-radial-samples")
 kspace_loc = radial_mask.data
 density_comp = estimate_density_compensation(kspace_loc, image.shape)
@@ -56,6 +57,8 @@ fourier_op_density_comp = NonCartesianFFT(
     implementation='gpuNUFFT',
     density_comp=density_comp
 )
+# Get the kspace data retrospectively. Note that this can be done with
+# `fourier_op_density_comp` as the forward operator is the same
 kspace_obs = fourier_op.op(image.data)
 
 # Simple adjoint

--- a/examples/GPU_Examples/NonCartesian_gpuNUFFT_DensityCompensation.py
+++ b/examples/GPU_Examples/NonCartesian_gpuNUFFT_DensityCompensation.py
@@ -67,7 +67,8 @@ image_rec0 = pysap.Image(data=np.abs(fourier_op.adj_op(kspace_obs)))
 base_ssim = ssim(image_rec0, image)
 print('The SSIM from Adjoint is : ' + str(base_ssim))
 
-# Density Compensation adjoint
+# Density Compensation adjoint:
+# This preconditions k-space giving a result closer to inverse
 image_rec1 = pysap.Image(data=np.abs(
     fourier_op_density_comp.adj_op(kspace_obs))
 )

--- a/examples/GPU_Examples/NonCartesian_gpuNUFFT_SENSE_DensityCompensation.py
+++ b/examples/GPU_Examples/NonCartesian_gpuNUFFT_SENSE_DensityCompensation.py
@@ -4,14 +4,14 @@ Neuroimaging non-cartesian reconstruction
 
 Author: Chaithya G R
 
-In this tutorial we will reconstruct an MRI directly with density compensation
-and SENSE from gpuNUFFT
+In this tutorial we will reconstruct an MR Image directly with density
+compensation and SENSE from gpuNUFFT
 
 Import neuroimaging data
 ------------------------
 
 We use the toy datasets available in pysap, more specifically a 3D orange data
-and the acquisition non-cartesian 3D radial scheme.
+and the radial acquisition scheme (non-cartesian).
 """
 
 # Package import
@@ -34,7 +34,7 @@ import numpy as np
 image = get_sample_data('3d-pmri')
 cartesian = np.linalg.norm(image, axis=0)
 
-# Obtain MRI non-cartesian mask
+# Obtain MRI non-cartesian mask and estimate the density compensation
 radial_mask = get_sample_data("mri-radial-3d-samples")
 kspace_loc = radial_mask.data
 density_comp = estimate_density_compensation(kspace_loc, cartesian.shape)
@@ -75,7 +75,8 @@ fourier_op_sense_dc = NonCartesianFFT(
     smaps=Smaps,
 )
 
-# Density Compensation SENSE adjoint
+# Density Compensation SENSE adjoint:
+# This preconditions k-space giving a result closer to inverse
 image_rec1 = pysap.Image(data=np.abs(
     fourier_op_sense_dc.adj_op(kspace_obs))
 )

--- a/examples/GPU_Examples/NonCartesian_gpuNUFFT_SENSE_DensityCompensation.py
+++ b/examples/GPU_Examples/NonCartesian_gpuNUFFT_SENSE_DensityCompensation.py
@@ -76,7 +76,10 @@ fourier_op_sense_dc = NonCartesianFFT(
 )
 
 # Density Compensation SENSE adjoint
-image_rec1 = pysap.Image(data=np.abs(fourier_op_sense_dc.adj_op(kspace_obs)))
+image_rec1 = pysap.Image(data=np.abs(
+    fourier_op_sense_dc.adj_op(kspace_obs))
+)
 # image_rec1.show()
 base_ssim = ssim(image_rec1, cartesian)
-print('The SSIM for simple Density compensated SENSE Adjoint is : ' + str(base_ssim))
+print('The SSIM for simple Density '
+      'compensated SENSE Adjoint is : ' + str(base_ssim))

--- a/examples/GPU_Examples/NonCartesian_gpuNUFFT_SENSE_DensityCompensation.py
+++ b/examples/GPU_Examples/NonCartesian_gpuNUFFT_SENSE_DensityCompensation.py
@@ -1,0 +1,82 @@
+"""
+Neuroimaging non-cartesian reconstruction
+=========================================
+
+Author: Chaithya G R
+
+In this tutorial we will reconstruct an MRI directly with density compensation
+and SENSE from gpuNUFFT
+
+Import neuroimaging data
+------------------------
+
+We use the toy datasets available in pysap, more specifically a 3D orange data
+and the acquisition non-cartesian 3D radial scheme.
+"""
+
+# Package import
+from mri.operators import NonCartesianFFT, WaveletUD2
+from mri.operators.utils import convert_locations_to_mask, \
+    gridded_inverse_fourier_transform_nd
+from mri.operators.fourier.utils import estimate_density_compensation
+from mri.reconstructors import SingleChannelReconstructor
+from mri.reconstructors.utils.extract_sensitivity_maps import get_Smaps
+import pysap
+from pysap.data import get_sample_data
+
+# Third party import
+from modopt.math.metrics import ssim
+from modopt.opt.linear import Identity
+from modopt.opt.proximity import SparseThreshold
+import numpy as np
+
+# Loading input data
+image = get_sample_data('3d-pmri')
+cartesian = np.linalg.norm(image, axis=0)
+
+# Obtain MRI non-cartesian mask
+radial_mask = get_sample_data("mri-radial-3d-samples")
+kspace_loc = radial_mask.data
+density_comp = estimate_density_compensation(kspace_loc, cartesian.shape)
+
+#############################################################################
+# Generate the kspace
+# -------------------
+#
+# From the 3D orange slice and 3D radial acquisition mask, we retrospectively
+# undersample the k-space
+# We then reconstruct using adjoint with and without density compensation
+
+# Get the locations of the kspace samples and the associated observations
+fourier_op = NonCartesianFFT(
+    samples=kspace_loc,
+    shape=cartesian.shape,
+    n_coils=image.shape[0],
+    implementation='gpuNUFFT',
+)
+kspace_obs = fourier_op.op(image.data)
+Smaps, SOS = get_Smaps(
+    k_space=kspace_obs,
+    img_shape=fourier_op.shape,
+    samples=kspace_loc,
+    thresh=(0.05, 0.05, 0.05),  # The cutoff threshold in each kspace
+                                # direction between 0 and kspace_max (0.5)
+    min_samples=kspace_loc.min(axis=0),
+    max_samples=kspace_loc.max(axis=0),
+    density_comp=density_comp,
+    mode='NFFT',
+)
+fourier_op_sense_dc = NonCartesianFFT(
+    samples=kspace_loc,
+    shape=cartesian.shape,
+    implementation='gpuNUFFT',
+    n_coils=image.shape[0],
+    density_comp=density_comp,
+    smaps=Smaps,
+)
+
+# Density Compensation SENSE adjoint
+image_rec1 = pysap.Image(data=np.abs(fourier_op_sense_dc.adj_op(kspace_obs)))
+# image_rec1.show()
+base_ssim = ssim(image_rec1, cartesian)
+print('The SSIM for simple Density compensated SENSE Adjoint is : ' + str(base_ssim))

--- a/mri/operators/fourier/non_cartesian.py
+++ b/mri/operators/fourier/non_cartesian.py
@@ -472,6 +472,9 @@ class gpuNUFFT:
         ----------
         image: np.ndarray
             input array with the same shape as shape.
+        interpolate_data: bool, default False
+            if set to True, the image is just apodized and interpolated to
+            kspace locations. This is used for density estimation.
 
         Returns
         -------
@@ -486,7 +489,10 @@ class gpuNUFFT:
                 [np.reshape(image_ch.T, image_ch.size) for image_ch in image]
             ).T, interpolate_data)
         else:
-            coeff = self.operator.op(np.reshape(image.T, image.size), interpolate_data)
+            coeff = self.operator.op(
+                np.reshape(image.T, image.size),
+                interpolate_data
+            )
             # Data is always returned as num_channels X coeff_array,
             # so for single channel, we extract single array
             if not self.uses_sense:
@@ -501,7 +507,9 @@ class gpuNUFFT:
         ----------
         coeff: np.ndarray
             masked non-uniform Fourier transform 1D data.
-
+        grid_data: bool, default False
+            if True, the kspace data is gridded and returned,
+            this is used for density compensation
         Returns
         -------
         np.ndarray
@@ -603,9 +611,13 @@ class NonCartesianFFT(OperatorBase):
         """
         if not isinstance(self.implementation, gpuNUFFT) and \
                 self.density_comp is not None:
-            return self.implementation.adj_op(coeffs * self.density_comp, *args)
+            return self.implementation.adj_op(
+                coeffs * self.density_comp,
+                *args
+            )
         else:
             return self.implementation.adj_op(coeffs, *args)
+
 
 class Stacked3DNFFT(OperatorBase):
     """"  3-D non uniform Fast Fourier Transform class,

--- a/mri/operators/fourier/non_cartesian.py
+++ b/mri/operators/fourier/non_cartesian.py
@@ -27,12 +27,13 @@ except Exception:
     warnings.warn("pynfft python package has not been found. If needed use "
                   "the master release.")
     pass
+pynufft_available = False
 try:
     from pynufft import NUFFT_hsa, NUFFT_cpu
 except Exception:
-    warnings.warn("pynufft python package has not been found. If needed use "
-                  "the master release. Till then you cannot use NUFFT on GPU")
     pass
+else:
+    pynufft_available = True
 
 gpunufft_available = False
 try:
@@ -236,6 +237,10 @@ class NUFFT(Singleton):
         """
         if (n_coils < 1) or (type(n_coils) is not int):
             raise ValueError('The number of coils should be an integer >= 1')
+        if not pynufft_available:
+            raise ValueError('PyNUFFT Package is not installed, please '
+                             'consider using `gpuNUFFT` or install the '
+                             'PyNUFFT package')
         self.nb_coils = n_coils
         self.shape = shape
         self.platform = platform

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -340,5 +340,4 @@ def estimate_density_compensation(kspace_loc, volume_shape, num_iterations=10):
                 density_comp /
                 np.abs(grid_op.op(grid_op.adj_op(density_comp, True), True))
         )
-    del grid_op
     return density_comp

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -309,6 +309,7 @@ def check_if_fourier_op_uses_sense(fourier_op):
     else:
         return False
 
+
 def estimate_density_compensation(kspace_loc, volume_shape, num_iterations=10):
     """ Utils function to obtain the density compensator for a
     given set of kspace locations.
@@ -330,8 +331,10 @@ def estimate_density_compensation(kspace_loc, volume_shape, num_iterations=10):
         osf=1,
     )
     density_comp = np.ones(kspace_loc.shape[0])
-    for _ in range(10):
-        density_comp = (density_comp /
-            np.abs(grid_op.op(grid_op.adj_op(density_comp, True), True)))
+    for _ in range(num_iterations):
+        density_comp = (
+                density_comp /
+                np.abs(grid_op.op(grid_op.adj_op(density_comp, True), True))
+        )
     del grid_op
     return density_comp

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -324,6 +324,10 @@ def estimate_density_compensation(kspace_loc, volume_shape, num_iterations=10):
         the number of iterations for density estimation
     """
     from .non_cartesian import NonCartesianFFT
+    from .non_cartesian import gpunufft_available
+    if gpunufft_available is False:
+        raise ValueError("gpuNUFFT is not available, cannot "
+                         "estimate the density compensation")
     grid_op = NonCartesianFFT(
         samples=kspace_loc,
         shape=volume_shape,

--- a/mri/reconstructors/utils/extract_sensitivity_maps.py
+++ b/mri/reconstructors/utils/extract_sensitivity_maps.py
@@ -51,7 +51,9 @@ def extract_k_space_center_and_locations(data_values, samples_locations,
         use density compensated adjoint for Smap estimation
     Returns
     -------
-    The extracted center of the k-space
+    The extracted center of the k-space. If the density compensators are
+    passed, the corresponding compensators for the center of k-space data
+    will also be returned.
     """
     if thr is None:
         if img_shape is None:
@@ -143,7 +145,7 @@ def get_Smaps(k_space, img_shape, samples, thresh,
             or len(thresh) != len(img_shape):
         raise NameError('The img_shape, max_samples, '
                         'min_samples and thresh must be of same length')
-    k_space, *samples = \
+    k_space, samples, *density_comp = \
         extract_k_space_center_and_locations(
             data_values=k_space,
             samples_locations=samples,
@@ -152,10 +154,8 @@ def get_Smaps(k_space, img_shape, samples, thresh,
             is_fft=mode == 'FFT',
             density_comp=density_comp,
         )
-    if density_comp is not None:
-        samples, density_comp = samples
-    else:
-        samples = samples[0]
+    if density_comp:
+        density_comp = density_comp[0]
     if samples is None:
         mode = 'FFT'
     L, M = k_space.shape

--- a/mri/reconstructors/utils/extract_sensitivity_maps.py
+++ b/mri/reconstructors/utils/extract_sensitivity_maps.py
@@ -156,6 +156,8 @@ def get_Smaps(k_space, img_shape, samples, thresh,
         )
     if density_comp:
         density_comp = density_comp[0]
+    else:
+        density_comp = None
     if samples is None:
         mode = 'FFT'
     L, M = k_space.shape

--- a/mri/reconstructors/utils/extract_sensitivity_maps.py
+++ b/mri/reconstructors/utils/extract_sensitivity_maps.py
@@ -51,9 +51,10 @@ def extract_k_space_center_and_locations(data_values, samples_locations,
         use density compensated adjoint for Smap estimation
     Returns
     -------
-    The extracted center of the k-space. If the density compensators are
-    passed, the corresponding compensators for the center of k-space data
-    will also be returned.
+    The extracted center of the k-space, i.e. both the kspace locations and
+    kspace values. If the density compensators are passed, the corresponding
+    compensators for the center of k-space data will also be returned. The
+    return stypes for density compensation and kspace data is same as input
     """
     if thr is None:
         if img_shape is None:

--- a/mri/reconstructors/utils/extract_sensitivity_maps.py
+++ b/mri/reconstructors/utils/extract_sensitivity_maps.py
@@ -15,6 +15,7 @@ import warnings
 
 # Package import
 from mri.operators import NonCartesianFFT
+from mri.operators.fourier.non_cartesian import gpunufft_available
 from mri.operators.utils import get_stacks_fourier, \
     gridded_inverse_fourier_transform_nd, \
     gridded_inverse_fourier_transform_stack, convert_locations_to_mask
@@ -27,7 +28,7 @@ import scipy.fftpack as pfft
 
 def extract_k_space_center_and_locations(data_values, samples_locations,
                                          thr=None, img_shape=None,
-                                         is_fft=False):
+                                         is_fft=False, density_comp=None):
     """
     This class extract the k space center for a given threshold and extracts
     the corresponding sampling locations
@@ -45,6 +46,9 @@ def extract_k_space_center_and_locations(data_values, samples_locations,
     is_fft: bool default False
         Checks if the incoming data is from FFT, in which case, masking
         can be done more directly
+    density_comp: np.ndarray default None
+        The density compensation for kspace data in case it exists and we
+        use density compensated adjoint for Smap estimation
     Returns
     -------
     The extracted center of the k-space
@@ -76,12 +80,15 @@ def extract_k_space_center_and_locations(data_values, samples_locations,
         index = np.extract(condition, index)
         center_locations = samples_locations[index, :]
         data_thresholded = data_ordered[:, index]
-    return data_thresholded, center_locations
+        if density_comp is not None:
+            density_comp = density_comp[index]
+    return data_thresholded, center_locations, density_comp
 
 
 def get_Smaps(k_space, img_shape, samples, thresh,
               min_samples, max_samples, mode='Gridding',
-              method='linear', n_cpu=1):
+              method='linear', density_comp=None, n_cpu=1,
+              fourier_op_kwargs=None):
     """
     This method estimate the sensitivity maps information from parallel mri
     acquisition and for variable density sampling scheme where teh k-space
@@ -111,8 +118,15 @@ def get_Smaps(k_space, img_shape, samples, thresh,
         been sampled on the grid
     method: string 'linear' | 'cubic' | 'nearest', default='linear'
         For gridding mode, it defines the way interpolation must be done
-    n_cpu: intm default=1
+    density_comp: np.ndarray default None
+        The density compensation for kspace data in case it exists and we
+        use density compensated adjoint for Smap estimation
+    n_cpu: int default=1
         Number of parallel jobs in case of parallel MRI
+    fourier_op_kwargs: dict, default None
+        The keyword arguments given to fourier_op initialization if
+        mode == 'NFFT'. If None, we choose implementation of fourier op to
+        'gpuNUFFT' if library is installed.
 
     Returns
     -------
@@ -127,13 +141,15 @@ def get_Smaps(k_space, img_shape, samples, thresh,
             or len(thresh) != len(img_shape):
         raise NameError('The img_shape, max_samples, '
                         'min_samples and thresh must be of same length')
-    k_space, samples = \
+    k_space, samples, density_comp = \
         extract_k_space_center_and_locations(
             data_values=k_space,
             samples_locations=samples,
             thr=thresh,
             img_shape=img_shape,
-            is_fft=mode == 'FFT')
+            is_fft=mode == 'FFT',
+            density_comp=density_comp,
+        )
     if samples is None:
         mode = 'FFT'
     L, M = k_space.shape
@@ -148,9 +164,19 @@ def get_Smaps(k_space, img_shape, samples, thresh,
         for l in range(Smaps_shape[2]):
             Smaps[l] = pfft.ifftshift(pfft.ifft2(pfft.fftshift(k_space[l])))
     elif mode == 'NFFT':
-        fourier_op = NonCartesianFFT(samples=samples, shape=img_shape,
-                                     implementation='cpu')
-        Smaps = np.asarray([fourier_op.adj_op(k_space[l]) for l in range(L)])
+        if fourier_op_kwargs is None:
+            if gpunufft_available:
+                fourier_op_kwargs = {'implementation': 'gpuNUFFT'}
+            else:
+                fourier_op_kwargs = {}
+        fourier_op = NonCartesianFFT(
+            samples=samples,
+            shape=img_shape,
+            density_comp=density_comp,
+            n_coils=L,
+            **fourier_op_kwargs,
+        )
+        Smaps = fourier_op.adj_op(np.ascontiguousarray(k_space))
     elif mode == 'Stack':
         grid_space = [np.linspace(min_samples[i],
                                   max_samples[i],

--- a/mri/reconstructors/utils/extract_sensitivity_maps.py
+++ b/mri/reconstructors/utils/extract_sensitivity_maps.py
@@ -82,7 +82,9 @@ def extract_k_space_center_and_locations(data_values, samples_locations,
         data_thresholded = data_ordered[:, index]
         if density_comp is not None:
             density_comp = density_comp[index]
-    return data_thresholded, center_locations, density_comp
+            return data_thresholded, center_locations, density_comp
+        else:
+            return data_thresholded, center_locations
 
 
 def get_Smaps(k_space, img_shape, samples, thresh,
@@ -141,7 +143,7 @@ def get_Smaps(k_space, img_shape, samples, thresh,
             or len(thresh) != len(img_shape):
         raise NameError('The img_shape, max_samples, '
                         'min_samples and thresh must be of same length')
-    k_space, samples, density_comp = \
+    k_space, *samples = \
         extract_k_space_center_and_locations(
             data_values=k_space,
             samples_locations=samples,
@@ -150,6 +152,10 @@ def get_Smaps(k_space, img_shape, samples, thresh,
             is_fft=mode == 'FFT',
             density_comp=density_comp,
         )
+    if density_comp is not None:
+        samples, density_comp = samples
+    else:
+        samples = samples[0]
     if samples is None:
         mode = 'FFT'
     L, M = k_space.shape

--- a/mri/test_local/test_fourier_adjoint_gpu.py
+++ b/mri/test_local/test_fourier_adjoint_gpu.py
@@ -25,7 +25,7 @@ class TestAdjointOperatorFourierTransformGPU(unittest.TestCase):
         """
         self.N = 128
         self.num_channels = [1, 16]
-        self.platforms = ['gpuNUFFT']#, 'cuda', 'opencl']
+        self.platforms = ['gpuNUFFT', 'cuda', 'opencl']
 
     def test_NUFFT_3D(self):
         """Test the adjoint operator for the 3D non-Cartesian Fourier transform

--- a/mri/test_local/test_fourier_adjoint_gpu.py
+++ b/mri/test_local/test_fourier_adjoint_gpu.py
@@ -23,9 +23,9 @@ class TestAdjointOperatorFourierTransformGPU(unittest.TestCase):
     def setUp(self):
         """ Set the number of iterations.
         """
-        self.N = 64
+        self.N = 128
         self.num_channels = [1, 16]
-        self.platforms = ['gpuNUFFT', 'cuda', 'opencl']
+        self.platforms = ['gpuNUFFT']#, 'cuda', 'opencl']
 
     def test_NUFFT_3D(self):
         """Test the adjoint operator for the 3D non-Cartesian Fourier transform
@@ -35,11 +35,12 @@ class TestAdjointOperatorFourierTransformGPU(unittest.TestCase):
             for platform in self.platforms:
                 _mask = np.random.randint(2, size=(self.N, self.N, self.N))
                 _samples = convert_mask_to_locations(_mask)
-                fourier_op_dir = NonCartesianFFT(samples=_samples,
-                                                 shape=(self.N, self.N,
-                                                        self.N),
-                                                 implementation=platform,
-                                                 n_coils=num_channels)
+                fourier_op_dir = NonCartesianFFT(
+                    samples=_samples,
+                    shape=(self.N, self.N, self.N),
+                    implementation=platform,
+                    n_coils=num_channels
+                )
                 Img = (np.random.randn(num_channels, self.N, self.N, self.N) +
                        1j * np.random.randn(num_channels, self.N, self.N,
                                             self.N))
@@ -62,14 +63,17 @@ class TestAdjointOperatorFourierTransformGPU(unittest.TestCase):
             for platform in self.platforms:
                 _mask = np.random.randint(2, size=(self.N, self.N))
                 _samples = convert_mask_to_locations(_mask)
-                fourier_op_adj = NonCartesianFFT(samples=_samples,
-                                                 shape=(self.N, self.N),
-                                                 implementation=platform,
-                                                 n_coils=num_channels)
+                fourier_op_adj = NonCartesianFFT(
+                    samples=_samples,
+                    shape=(self.N, self.N),
+                    implementation=platform,
+                    n_coils=num_channels,
+                    density_comp=np.ones((num_channels, _samples.shape[0]))
+                )
                 Img = (np.random.randn(num_channels, self.N, self.N) +
                        1j * np.random.randn(num_channels, self.N, self.N))
-                f = (np.random.randn(num_channels, _samples.shape[0], 1) +
-                     1j * np.random.randn(num_channels, _samples.shape[0], 1))
+                f = (np.random.randn(num_channels, _samples.shape[0]) +
+                     1j * np.random.randn(num_channels, _samples.shape[0]))
                 f_p = fourier_op_adj.op(Img)
                 I_p = fourier_op_adj.adj_op(f)
                 x_d = np.vdot(Img, I_p)

--- a/mri/test_local/test_fourier_adjoint_gpu.py
+++ b/mri/test_local/test_fourier_adjoint_gpu.py
@@ -23,7 +23,7 @@ class TestAdjointOperatorFourierTransformGPU(unittest.TestCase):
     def setUp(self):
         """ Set the number of iterations.
         """
-        self.N = 128
+        self.N = 64
         self.num_channels = [1, 16]
         self.platforms = ['gpuNUFFT', 'cuda', 'opencl']
 

--- a/mri/test_local/test_fourier_adjoint_gpu.py
+++ b/mri/test_local/test_fourier_adjoint_gpu.py
@@ -35,12 +35,11 @@ class TestAdjointOperatorFourierTransformGPU(unittest.TestCase):
             for platform in self.platforms:
                 _mask = np.random.randint(2, size=(self.N, self.N, self.N))
                 _samples = convert_mask_to_locations(_mask)
-                fourier_op_dir = NonCartesianFFT(
-                    samples=_samples,
-                    shape=(self.N, self.N, self.N),
-                    implementation=platform,
-                    n_coils=num_channels
-                )
+                fourier_op_dir = NonCartesianFFT(samples=_samples,
+                                                 shape=(self.N, self.N,
+                                                        self.N),
+                                                 implementation=platform,
+                                                 n_coils=num_channels)
                 Img = (np.random.randn(num_channels, self.N, self.N, self.N) +
                        1j * np.random.randn(num_channels, self.N, self.N,
                                             self.N))

--- a/mri/tests/test_fourier_adjoint.py
+++ b/mri/tests/test_fourier_adjoint.py
@@ -113,7 +113,9 @@ class TestAdjointOperatorFourierTransform(unittest.TestCase):
         print(" FFT adjoint test passes")
 
     def test_NFFT_2D(self):
-        """Test the adjoint operator for the 2D non-Cartesian Fourier transform
+        """Test the adjoint operator for the 2D non-Cartesian Fourier transform,
+        with density compensator set to 1, to vet the code path, the test is
+        unchanged otherwise
         """
         for num_channels in self.num_channels:
             print("Testing with num_channels=" + str(num_channels))
@@ -121,10 +123,13 @@ class TestAdjointOperatorFourierTransform(unittest.TestCase):
                 _mask = np.random.randint(2, size=(self.N, self.N))
                 _samples = convert_mask_to_locations(_mask)
                 print("Process NFFT in 2D test '{0}'...", i)
-                fourier_op = NonCartesianFFT(samples=_samples,
-                                             shape=(self.N, self.N),
-                                             n_coils=num_channels,
-                                             implementation='cpu')
+                fourier_op = NonCartesianFFT(
+                    samples=_samples,
+                    shape=(self.N, self.N),
+                    n_coils=num_channels,
+                    implementation='cpu',
+                    density_comp=np.ones((num_channels, _samples.shape[0]))
+                )
                 Img = np.random.randn(num_channels, self.N, self.N) + \
                     1j * np.random.randn(num_channels, self.N, self.N)
                 f = np.random.randn(num_channels, _samples.shape[0]) + \

--- a/mri/tests/test_fourier_adjoint.py
+++ b/mri/tests/test_fourier_adjoint.py
@@ -113,9 +113,9 @@ class TestAdjointOperatorFourierTransform(unittest.TestCase):
         print(" FFT adjoint test passes")
 
     def test_NFFT_2D(self):
-        """Test the adjoint operator for the 2D non-Cartesian Fourier transform,
-        with density compensator set to 1, to vet the code path, the test is
-        unchanged otherwise
+        """Test the adjoint operator for the 2D non-Cartesian Fourier
+        transform, with density compensator set to 1, to vet the code
+        path, the test is unchanged otherwise
         """
         for num_channels in self.num_channels:
             print("Testing with num_channels=" + str(num_channels))

--- a/mri/tests/test_sensitivity_extraction.py
+++ b/mri/tests/test_sensitivity_extraction.py
@@ -133,7 +133,7 @@ class TestSensitivityExtraction(unittest.TestCase):
             min_samples=(-0.5, -0.5),
             max_samples=(0.5, 0.5),
             n_cpu=1)
-        Smaps_NFFT, SOS_Smaps = get_Smaps(
+        Smaps_NFFT_dc, SOS_Smaps_dc = get_Smaps(
             k_space=F_img,
             img_shape=(self.N, self.N),
             thresh=(0.4, 0.4),
@@ -143,6 +143,16 @@ class TestSensitivityExtraction(unittest.TestCase):
             mode='NFFT',
             density_comp=np.ones(samples.shape[0])
         )
+        Smaps_NFFT, SOS_Smaps = get_Smaps(
+            k_space=F_img,
+            img_shape=(self.N, self.N),
+            thresh=(0.4, 0.4),
+            samples=samples,
+            min_samples=(-0.5, -0.5),
+            max_samples=(0.5, 0.5),
+            mode='NFFT',
+        )
+        np.testing.assert_allclose(Smaps_gridding, Smaps_NFFT_dc)
         np.testing.assert_allclose(Smaps_gridding, Smaps_NFFT)
         # Test that we raise assert for bad mode
         np.testing.assert_raises(

--- a/mri/tests/test_sensitivity_extraction.py
+++ b/mri/tests/test_sensitivity_extraction.py
@@ -63,9 +63,10 @@ class TestSensitivityExtraction(unittest.TestCase):
             data_thresholded)
 
     def test_extract_k_space_center_2D(self):
-        """ Ensure that the extracted k-space center is right"""
-        _mask = np.ones((self.N, self.N))
-        _samples = convert_mask_to_locations(_mask)
+        """ Ensure that the extracted k-space center is right,
+        send density compensation also and vet the code path"""
+        mask = np.ones((self.N, self.N))
+        samples = convert_mask_to_locations(mask)
         Img = (np.random.randn(self.num_channel, self.N, self.N) +
                1j * np.random.randn(self.num_channel, self.N, self.N))
         Nby2_percent = self.N * self.percent / 2
@@ -73,13 +74,15 @@ class TestSensitivityExtraction(unittest.TestCase):
         high = int(self.N / 2 + Nby2_percent + 1)
         center_Img = Img[:, low:high, low:high]
         thresh = self.percent * 0.5
-        data_thresholded, samples_thresholded = \
+        data_thresholded, samples_thresholded, dc = \
             extract_k_space_center_and_locations(
                 data_values=np.reshape(Img, (self.num_channel,
                                              self.N * self.N)),
-                samples_locations=_samples,
+                samples_locations=samples,
                 thr=(thresh, thresh),
-                img_shape=(self.N, self.N))
+                img_shape=(self.N, self.N),
+                density_comp=np.ones(samples.shape[0])
+            )
         np.testing.assert_allclose(
             center_Img.reshape(data_thresholded.shape),
             data_thresholded)
@@ -114,9 +117,9 @@ class TestSensitivityExtraction(unittest.TestCase):
         """ This test ensures that the output of the non cartesian kspace
         extraction is same a that of mimicked cartesian extraction in 2D
         """
-        _mask = np.ones((self.N, self.N))
-        _samples = convert_mask_to_locations(_mask)
-        fourier_op = NonCartesianFFT(samples=_samples, shape=(self.N, self.N))
+        mask = np.ones((self.N, self.N))
+        samples = convert_mask_to_locations(mask)
+        fourier_op = NonCartesianFFT(samples=samples, shape=(self.N, self.N))
         Img = (np.random.randn(self.num_channel, self.N, self.N) +
                1j * np.random.randn(self.num_channel, self.N, self.N))
         F_img = np.asarray([fourier_op.op(Img[i])
@@ -124,7 +127,7 @@ class TestSensitivityExtraction(unittest.TestCase):
         Smaps_gridding, SOS_Smaps = get_Smaps(
             k_space=F_img,
             img_shape=(self.N, self.N),
-            samples=_samples,
+            samples=samples,
             thresh=(0.4, 0.4),
             mode='gridding',
             min_samples=(-0.5, -0.5),
@@ -134,10 +137,12 @@ class TestSensitivityExtraction(unittest.TestCase):
             k_space=F_img,
             img_shape=(self.N, self.N),
             thresh=(0.4, 0.4),
-            samples=_samples,
+            samples=samples,
             min_samples=(-0.5, -0.5),
             max_samples=(0.5, 0.5),
-            mode='NFFT')
+            mode='NFFT',
+            density_comp=np.ones(samples.shape[0])
+        )
         np.testing.assert_allclose(Smaps_gridding, Smaps_NFFT)
         # Test that we raise assert for bad mode
         np.testing.assert_raises(
@@ -146,7 +151,7 @@ class TestSensitivityExtraction(unittest.TestCase):
             k_space=F_img,
             img_shape=(self.N, self.N),
             thresh=(0.4, 0.4),
-            samples=_samples,
+            samples=samples,
             min_samples=(-0.5, -0.5),
             max_samples=(0.5, 0.5),
             mode='test'


### PR DESCRIPTION
I have made a quick pypi release of gpuNUFFT with support for density estimation. 

This PR mainly handles all the codes to have density compensation based reconstructions.

Starting the review as it is pretty much complete from my side (except any upcoming issues). This is the final PR before an official release of pysap-mri !!

Adding @Daval-G for testing the codes, please follow the methods and let me know if you face any issues.
Adding @zaccharieramzi in meantime for code and doc review.