### PR TITLE
Fix normalize_frequency_locations

### DIFF
--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -97,11 +97,11 @@ def normalize_frequency_locations(samples, Kmax=None):
     """
     samples_locations = np.copy(samples.astype('float'))
     if Kmax is None:
-        Kmax = 2*np.abs(samples_locations).max(axis=0)
+        Kmax = np.abs(samples_locations).max(axis=0)
     elif isinstance(Kmax, (float, int)):
         Kmax = [Kmax] * samples_locations.shape[-1]
     Kmax = np.array(Kmax)
-    samples_locations /= Kmax
+    samples_locations /= (2 * Kmax)
     if samples_locations.max() == 0.5:
         warnings.warn("Frequency equal to 0.5 will be put in -0.5")
         samples_locations[np.where(samples_locations == 0.5)] = -0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test = pytest
 
 [tool:pytest]
-addopts = --verbose --pep8 --cov=mri --cov-config=.coveragerc --ignore-glob='*test_local*.py'
+addopts = --verbose --cov=mri --cov-config=.coveragerc --ignore-glob='*test_local*.py'
 testpaths = mri/tests/


### PR DESCRIPTION
We fix the `normalize_frequency_locations` function as addressed in #112 
This is a quick single line change

Also, in this PR, I am removing PEP8 checks from pytest, as they are redundant, we already have these checks from `pycodestyle`.
Also, it looks like there are some test failures currently due to some change in pytest for PEP8 checks