### PR TITLE
Preparing for a release v0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             . venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade git+https://github.com/cea-cosmic/pysap
-            pip install -r --upgrade doc/requirements.txt
+            pip install --upgrade -r doc/requirements.txt
             pip list > doc/state.txt
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
             pip install --upgrade pip
             pip install Cython
             pip install -e .
+            pip install pynfft2
             TESTFILES=$(circleci tests glob examples/*.py | circleci tests split --split-by=timings)
             echo ${TESTFILES}
             python3 -m unittest ${TESTFILES}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
             . venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade git+https://github.com/cea-cosmic/pysap
-            pip install -r doc/requirements.txt
+            pip install -r --upgrade doc/requirements.txt
             pip list > doc/state.txt
       - save_cache:
           paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     - pip install git+https://github.com/CEA-COSMIC/pysap.git
     - export PYTHONPATH=$TRAVIS_BUILD_DIR/install:$PYTHONPATH
     - pip install -b $TRAVIS_BUILD_DIR/build -t $TRAVIS_BUILD_DIR/install --no-clean --upgrade .
-    - pip install pyNFFT2
+    - pip install pynfft2
 
 script:
     - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ install:
     - pip install git+https://github.com/CEA-COSMIC/pysap.git
     - export PYTHONPATH=$TRAVIS_BUILD_DIR/install:$PYTHONPATH
     - pip install -b $TRAVIS_BUILD_DIR/build -t $TRAVIS_BUILD_DIR/install --no-clean --upgrade .
+    - pip install pyNFFT2
 
 script:
     - python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -18,17 +18,21 @@ pySAP-mri
 Python Sparse data Analysis Package external MRI plugin.
 
 This work is made available by a community of people, amoung which the
-CEA Neurospin UNATI and CEA CosmoStat laboratories, in particular A. Grigis,
-J.-L. Starck, P. Ciuciu, and S. Farrens.
+CEA Neurospin UNATI and CEA CosmoStat laboratories. This plugin was developed by
+A. Grigis, J.-L. Starck, P. Ciuciu, and S. Farrens. Currently, it is being handled by
+Chaithya G R, Z. Ramzi and S. Farrens.
 
 Installation instructions
 =========================
 
-Install python-pySAP using `pip install python-pySAP`. Later install pysap-mri by calling setup.py
-Note: If you want to use undecimated wavelet transform, please point the `$PATH` environment variable to
-pysap external binary directory:
+Install python-pySAP using:
 
-`export PATH=$PATH:/path-to-pysap/build/temp.linux-x86_64-<PYTHON_VERSION>/extern/bin/`
+``pip install python-pysap``
+
+This will install pysap-mri plugin too. However if you want to update to a more
+later version, please use:
+
+``pip install --upgrade pysap-mri``
 
 Special Installations
 =====================
@@ -40,16 +44,19 @@ For using Non-Cartesian FFT, please install pyNFFT by:
 
 Linux:
 ``````
-1) Install libnfft3-dev
 
 ``sudo apt install libnfft3-dev``
-
-2) Install pyNFFT
 
 ``pip install pynfft2``
 
 Mac:
 ````
+
+``brew tap brewsci/science``
+
+``brew install nfft``
+
+``pip install pynfft``
 
 `gpuNUFFT <https://www.opensourceimaging.org/project/gpunufft/>`_
 ---------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,24 @@ pysap external binary directory:
 Special Installations
 =====================
 
+`pyNFFT <https://github.com/pyNFFT/pyNFFT/>'_
+--------------------------------------------
+
+For using Non-Cartesian FFT, please install pyNFFT by:
+
+
+Linux:
+
+1) Install libnfft3-dev
+`sudo apt install libnfft3-dev`
+
+2) Install pyNFFT
+`pip install pynfft2`
+
+
+Mac:
+
+
 `gpuNUFFT <https://www.opensourceimaging.org/project/gpunufft/>`_
 ---------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -33,23 +33,21 @@ pysap external binary directory:
 Special Installations
 =====================
 
-`pyNFFT <https://github.com/pyNFFT/pyNFFT/>'_
+`pyNFFT <https://github.com/pyNFFT/pyNFFT/>`_
 --------------------------------------------
 
 For using Non-Cartesian FFT, please install pyNFFT by:
 
-
 Linux:
-
+``````
 1) Install libnfft3-dev
 `sudo apt install libnfft3-dev`
 
 2) Install pyNFFT
 `pip install pynfft2`
 
-
 Mac:
-
+````
 
 `gpuNUFFT <https://www.opensourceimaging.org/project/gpunufft/>`_
 ---------------------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -41,10 +41,12 @@ For using Non-Cartesian FFT, please install pyNFFT by:
 Linux:
 ``````
 1) Install libnfft3-dev
-`sudo apt install libnfft3-dev`
+
+``sudo apt install libnfft3-dev``
 
 2) Install pyNFFT
-`pip install pynfft2`
+
+``pip install pynfft2``
 
 Mac:
 ````

--- a/README.rst
+++ b/README.rst
@@ -52,11 +52,7 @@ Linux:
 Mac:
 ````
 
-``brew tap brewsci/science``
-
-``brew install nfft``
-
-``pip install pynfft``
+``conda install -c conda-forge pynfft``
 
 `gpuNUFFT <https://www.opensourceimaging.org/project/gpunufft/>`_
 ---------------------------------------------------------------

--- a/mri/info.py
+++ b/mri/info.py
@@ -9,8 +9,8 @@
 
 # Module current version
 version_major = 0
-version_minor = 2
-version_micro = 2
+version_minor = 3
+version_micro = 0
 
 # Expected by setup.py: string of form "X.Y.Z"
 __version__ = "{0}.{1}.{2}".format(version_major, version_minor, version_micro)

--- a/mri/tests/test_scripts.py
+++ b/mri/tests/test_scripts.py
@@ -92,7 +92,8 @@ class TestScripts(unittest.TestCase):
         np.testing.assert_equal(best_idx, 0)
         np.testing.assert_allclose(
             raw_results[best_idx][0],
-            image
+            image,
+            atol=1e-7,
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         "progressbar2>=3.34.3",
         "joblib>=1.0.0",
         "scipy>=1.3.0",
-        "pynfft2>=1.3.3",
         "scikit-image>=0.18.0",
     ],
     tests_require=['pytest>=5.0.1', 'pytest-cov>=2.7.1', 'pytest-pep8', 'pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "progressbar2>=3.34.3",
         "joblib>=1.0.0",
         "scipy>=1.3.0",
-        "scikit-image>=0.18.0",
+        "scikit-image>=0.17.0",
     ],
     tests_require=['pytest>=5.0.1', 'pytest-cov>=2.7.1', 'pytest-pep8', 'pytest-runner'],
     platforms="OS Independent"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     classifiers="CLASSIFIERS",
     author=AUTHOR,
     author_email="XXX",
-    version="0.2.2",
+    version="0.3.0",
     url="https://github.com/CEA-COSMIC/pysap-mri",
     packages=find_packages(),
     setup_requires=setup_requires,

--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,10 @@ setup(
     install_requires=[
         "scikit-learn>=0.19.1",
         "progressbar2>=3.34.3",
-        "joblib",
+        "joblib>=1.0.0",
         "scipy>=1.3.0",
         "pynfft2>=1.3.3",
-        "scikit-image",
+        "scikit-image>=0.18.0",
     ],
     tests_require=['pytest>=5.0.1', 'pytest-cov>=2.7.1', 'pytest-pep8', 'pytest-runner'],
     platforms="OS Independent"


### PR DESCRIPTION
This PR holds the release for v0.3.
We will have pyNFFT as an optional install clearing the way for easier install for users. The README is appropriately updated.
Also, I have added the current maintainers/developers in the README.

The updates in this release include:

1) #118 Refactor and remove unwanted imports in CircleCI
2) #111 Fix FFT class, move to `scipy.fft` to better handle multi-process. Also fix the grid-search
3) #113 Fix the `normalize_frequency_locations` code to work well with given `KMax`
4) #114 Add oscar regularization based on `scale`