### PR TITLE
Add function to discard kspace locations out-of-bounds, and related tests

### DIFF
--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -79,8 +79,8 @@ def convert_locations_to_mask(samples_locations, img_shape):
 
 def normalize_frequency_locations(samples, Kmax=None):
     """
-    This function normalize the samples locations between [-0.5; 0.5[ for
-    the non-cartesian case
+    This function normalizes the sample locations between [-0.5; 0.5[ for
+    the non-Cartesian case.
 
     Parameters
     ----------
@@ -106,6 +106,33 @@ def normalize_frequency_locations(samples, Kmax=None):
         warnings.warn("Frequency equal to 0.5 will be put in -0.5")
         samples_locations[np.where(samples_locations == 0.5)] = -0.5
     return samples_locations
+
+
+def discard_frequency_outliers(kspace_loc, kspace_data):
+    """
+    This function discards the samples outside [-0.5; 0.5[ for
+    the non-Cartesian case.
+
+    Parameters
+    ----------
+    kspace_loc: np.ndarray
+        The sample locations previously normalized around [-0.5; 0.5[
+        using Kmax.
+    kspace_data: np.ndarray
+        The samples corresponding to kspace_loc defined above.
+
+    Returns
+    -------
+    reduced_kspace_loc: np.ndarray
+        The sample locations reduced strictly to [-0.5; 0.5[ by discarding
+        outliers.
+    reduced_kspace_data: np.ndarray
+        The samples corresponding to reduced_kspace_loc defined above.
+    """
+    kspace_mask = np.all((kspace_loc < 0.5) & (kspace_loc >= -0.5), axis=-1)
+    kspace_loc = kspace_loc[kspace_mask]
+    kspace_data = kspace_data[:, kspace_mask]
+    return kspace_loc, kspace_data
 
 
 def get_stacks_fourier(kspace_loc, volume_shape):

--- a/mri/operators/fourier/utils.py
+++ b/mri/operators/fourier/utils.py
@@ -132,7 +132,7 @@ def discard_frequency_outliers(kspace_loc, kspace_data):
     kspace_mask = np.all((kspace_loc < 0.5) & (kspace_loc >= -0.5), axis=-1)
     kspace_loc = kspace_loc[kspace_mask]
     kspace_data = kspace_data[:, kspace_mask]
-    return kspace_loc, kspace_data
+    return np.ascontiguousarray(kspace_loc), np.ascontiguousarray(kspace_data)
 
 
 def get_stacks_fourier(kspace_loc, volume_shape):

--- a/mri/operators/utils/__init__.py
+++ b/mri/operators/utils/__init__.py
@@ -12,7 +12,8 @@
 
 from ..fourier.utils import convert_mask_to_locations, \
     convert_locations_to_mask, normalize_frequency_locations, \
-    get_stacks_fourier, gridded_inverse_fourier_transform_nd, \
+    discard_frequency_outliers, get_stacks_fourier, \
+    gridded_inverse_fourier_transform_nd, \
     gridded_inverse_fourier_transform_stack, check_if_fourier_op_uses_sense
 from ..linear.utils import extract_patches_from_2d_images, min_max_normalize, \
     learn_dictionary


### PR DESCRIPTION
As opposed to previous PR #128, kspace samples located outside the [-0.5; 0.5[ limits should simply be discarded. Since this manipulation is not expected from `normalize_kspace_locations` and would represent an unwanted and redundant intermediate step inside the Fourier operators, it was preferred to simply add an utilitary function for the users.

Additional tests were added in `mri/tests/test_fourier_adjoint.py` for 2D and 3D by mimicking the `normalize_frequency_locations` tests. However, the latters had issues in their assertions and all four tests were properly updated to match the intended checks.