### PR TITLE
add dtype option for gradient.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,7 +47,7 @@ jobs:
           python -m pip install git+https://github.com/CEA-COSMIC/ModOpt.git@develop
           python -m pip install git+https://github.com/CEA-COSMIC/pysap.git@develop
           python -m pip install git+https://github.com/AGrigis/pysphinxdoc.git
-          python -m pip install coverage nose pytest pytest-cov pycodestyle twine pytest-xdist
+          python -m pip install coverage nose pytest pytest-cov pycodestyle pydocstyle twine pytest-xdist
           python -m pip install pynfft2
           python -m pip install --upgrade .
 
@@ -57,7 +57,8 @@ jobs:
         run: |
           pycodestyle mri --ignore="E121,E123,E126,E226,E24,E704,E402,E731,E722,E741,W503,W504,W605"
           pycodestyle examples --ignore="E121,E123,E126,E226,E24,E704,E402,E731,E722,E741,W503,W504,W605"
-
+          pydocstyle  mri --convention=numpy
+          pydocstyle  examples --convention=numpy
       - name: Run Tests
         shell: bash -l {0}
         run: |

--- a/mri/operators/gradient/base.py
+++ b/mri/operators/gradient/base.py
@@ -42,7 +42,7 @@ class GradBaseMRI(GradBasic):
     """
 
     def __init__(self, operator, trans_operator, shape,
-                 lips_calc_max_iter=10, lipschitz_cst=None, num_check_lips=10,
+                 lips_calc_max_iter=10, lipschitz_cst=None, dtype=np.complex64, num_check_lips=10,
                  verbose=0):
         # Initialize the GradBase with dummy data
         super(GradBaseMRI, self).__init__(
@@ -55,7 +55,8 @@ class GradBaseMRI(GradBasic):
             self.inv_spec_rad = 1.0 / self.spec_rad
         else:
             calc_lips = PowerMethod(self.trans_op_op, shape,
-                                    data_type=np.complex, auto_run=False)
+                                    data_type=dtype,
+                                    auto_run=False)
             calc_lips.get_spec_rad(extra_factor=1.1,
                                    max_iter=lips_calc_max_iter)
             self.spec_rad = calc_lips.spec_rad
@@ -65,6 +66,7 @@ class GradBaseMRI(GradBasic):
         if num_check_lips > 0:
             is_lips = check_lipschitz_cst(f=self.trans_op_op,
                                           x_shape=shape,
+                                          x_dtype=dtype,
                                           lipschitz_cst=self.spec_rad,
                                           max_nb_of_iter=num_check_lips)
             if not is_lips:

--- a/mri/operators/gradient/utils.py
+++ b/mri/operators/gradient/utils.py
@@ -20,7 +20,7 @@ This module contains all the utils tools needed in the p_MRI reconstruction.
 import numpy as np
 
 
-def check_lipschitz_cst(f, x_shape, lipschitz_cst, max_nb_of_iter=10):
+def check_lipschitz_cst(f, x_shape, lipschitz_cst, max_nb_of_iter=10, x_dtype=np.float64):
     """
     This methods check that for random entrees the lipschitz constraint are
     statisfied:
@@ -49,8 +49,8 @@ def check_lipschitz_cst(f, x_shape, lipschitz_cst, max_nb_of_iter=10):
 
     while is_lips_cst and n < max_nb_of_iter:
         n += 1
-        x = np.random.randn(*x_shape)
-        y = np.random.randn(*x_shape)
+        x = np.random.randn(*x_shape).astype(x_dtype)
+        y = np.random.randn(*x_shape).astype(x_dtype)
         is_lips_cst = (np.linalg.norm(f(x)-f(y)) <= (lipschitz_cst *
                                                      np.linalg.norm(x-y)))
 


### PR DESCRIPTION
This PR add the possibilty to specify the dtype of the gradient data used. 

This prevent bugs when using operator (especially NUFFT) which cannot handle all dtype (or do the casting by themselves).