### PR TITLE
Fourier operator base

### DIFF
--- a/doc/refs.bib
+++ b/doc/refs.bib
@@ -34,3 +34,11 @@
     year = {1997},
     pages = {785-792},
 }
+
+@article{Pruessmann1999,
+  title={SENSE: Sensitivity encoding for fast MRI},
+  author={Klaas Paul Pruessmann and Markus Weiger and Markus B. Scheidegger and Peter Boesiger},
+  journal={Magnetic Resonance in Medicine},
+  year={1999},
+  volume={42},
+}

--- a/mri/operators/fourier/base.py
+++ b/mri/operators/fourier/base.py
@@ -8,18 +8,14 @@
 """
 Base Fourier Operator.
 
-Every Fourier operator should have an `op` and `adj_op` methods.
-Also, it should exposes a `uses_sense` property to determine
-if it implement sensitivity maps support.
 """
-
 
 class FourierOperatorBase:
     """Base Fourier Operator class.
 
     Every (Linear) Fourier operator inherits from this class,
     to ensure that we have all the functions rightly implemented
-    as required by Modopt.
+    as required by ModOpt.
 
     Attributes
     ----------
@@ -27,6 +23,12 @@ class FourierOperatorBase:
     n_coils
     uses_sense
 
+    Methods
+    -------
+    op(data)
+        The forward operation (image -> kspace)
+    adj_op(coeffs)
+        The adjoint operation (kspace -> image)
     """
 
     def op(self, data):

--- a/mri/operators/fourier/base.py
+++ b/mri/operators/fourier/base.py
@@ -9,8 +9,9 @@
 Base Fourier Operator.
 
 """
+from ..base import OperatorBase
 
-class FourierOperatorBase:
+class FourierOperatorBase(OperatorBase):
     """Base Fourier Operator class.
 
     Every (Linear) Fourier operator inherits from this class,

--- a/mri/operators/fourier/base.py
+++ b/mri/operators/fourier/base.py
@@ -1,0 +1,58 @@
+# #############################################################################
+#  pySAP - Copyright (C) CEA, 2017 - 2018                                     #
+#  Distributed under the terms of the CeCILL-B license,                       #
+#  as published by the CEA-CNRS-INRIA. Refer to the LICENSE file or to        #
+#  http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html for details.   #
+# #############################################################################
+
+"""
+Base Fourier Operator.
+
+Every Fourier operator should have an `op` and `adj_op` methods.
+Also, it should exposes a `uses_sense` property to determine
+if it implement sensitivity maps support.
+"""
+
+
+class FourierOperatorBase:
+    """Base Fourier Operator class.
+
+    Every (Linear) Fourier operator inherits from this class,
+    to ensure that we have all the functions rightly implemented
+    as required by Modopt.
+    """
+
+    def op(self, data):
+        """Compute operator transform.
+
+        Parameters
+        ----------
+        data: np.ndarray
+            input as array.
+
+        Returns
+        -------
+        result: np.ndarray
+            operator transform of the input.
+        """
+        raise NotImplementedError("'op' is an abstract method.")
+
+    def adj_op(self, coeffs):
+        """Compute adjoint operator transform.
+
+        Parameters
+        ----------
+        x: np.ndarray
+            input data array.
+
+        Returns
+        -------
+        results: np.ndarray
+            adjoint operator transform.
+        """
+        raise NotImplementedError("'adj_op' is an abstract method.")
+
+    @property()
+    def uses_sense(self):
+        """Return True if the operator uses sensitivity maps."""
+        return False

--- a/mri/operators/fourier/base.py
+++ b/mri/operators/fourier/base.py
@@ -56,3 +56,23 @@ class FourierOperatorBase:
     def uses_sense(self):
         """Return True if the operator uses sensitivity maps."""
         return False
+
+    @property
+    def shape(self):
+        """Shape of the image space of the operator."""
+        return self._shape
+
+    @shape.setter
+    def shape(self, shape):
+        self._shape = tuple(shape)
+
+    @property
+    def n_coils(self):
+        """Return number of coil of the image space of the operator."""
+        return self._n_coils
+
+    @n_coils.setter
+    def n_coils(self, n_coils):
+        if n_coils < 1 or type(n_coils) is not int:
+            raise ValueError("n_coils should be a positive integer")
+        self._n_coils = n_coils

--- a/mri/operators/fourier/base.py
+++ b/mri/operators/fourier/base.py
@@ -20,6 +20,13 @@ class FourierOperatorBase:
     Every (Linear) Fourier operator inherits from this class,
     to ensure that we have all the functions rightly implemented
     as required by Modopt.
+
+    Attributes
+    ----------
+    shape
+    n_coils
+    uses_sense
+
     """
 
     def op(self, data):
@@ -42,7 +49,7 @@ class FourierOperatorBase:
 
         Parameters
         ----------
-        x: np.ndarray
+        coeffs: np.ndarray
             input data array.
 
         Returns
@@ -54,12 +61,24 @@ class FourierOperatorBase:
 
     @property
     def uses_sense(self):
-        """Return True if the operator uses sensitivity maps."""
+        """Check if the operator uses sensitivity maps ..cite:`Pruessmann1999`.
+
+        Returns
+        -------
+        bool
+            True if operator uses sensitivity maps.
+        """
         return False
 
     @property
     def shape(self):
-        """Shape of the image space of the operator."""
+        """Shape of the image space of the operator.
+
+        Returns
+        -------
+        tuple
+            The shape of the image space
+        """
         return self._shape
 
     @shape.setter
@@ -68,11 +87,18 @@ class FourierOperatorBase:
 
     @property
     def n_coils(self):
-        """Return number of coil of the image space of the operator."""
+        """Get the number of coil of the image space of the operator.
+
+        Returns
+        -------
+        int
+            The number of coils.
+
+        """
         return self._n_coils
 
     @n_coils.setter
     def n_coils(self, n_coils):
-        if n_coils < 1 or type(n_coils) is not int:
+        if n_coils < 1 or not isinstance(n_coils, int):
             raise ValueError("n_coils should be a positive integer")
         self._n_coils = n_coils

--- a/mri/operators/fourier/base.py
+++ b/mri/operators/fourier/base.py
@@ -52,7 +52,7 @@ class FourierOperatorBase:
         """
         raise NotImplementedError("'adj_op' is an abstract method.")
 
-    @property()
+    @property
     def uses_sense(self):
         """Return True if the operator uses sensitivity maps."""
         return False

--- a/mri/operators/fourier/base.py
+++ b/mri/operators/fourier/base.py
@@ -31,37 +31,6 @@ class FourierOperatorBase(OperatorBase):
     adj_op(coeffs)
         The adjoint operation (kspace -> image)
     """
-
-    def op(self, data):
-        """Compute operator transform.
-
-        Parameters
-        ----------
-        data: np.ndarray
-            input as array.
-
-        Returns
-        -------
-        result: np.ndarray
-            operator transform of the input.
-        """
-        raise NotImplementedError("'op' is an abstract method.")
-
-    def adj_op(self, coeffs):
-        """Compute adjoint operator transform.
-
-        Parameters
-        ----------
-        coeffs: np.ndarray
-            input data array.
-
-        Returns
-        -------
-        results: np.ndarray
-            adjoint operator transform.
-        """
-        raise NotImplementedError("'adj_op' is an abstract method.")
-
     @property
     def uses_sense(self):
         """Check if the operator uses sensitivity maps ..cite:`Pruessmann1999`.

--- a/mri/operators/fourier/base.py
+++ b/mri/operators/fourier/base.py
@@ -101,6 +101,6 @@ class FourierOperatorBase:
 
     @n_coils.setter
     def n_coils(self, n_coils):
-        if n_coils < 1 or not isinstance(n_coils, int):
+        if n_coils < 1 or not int(n_coils) == n_coils:
             raise ValueError("n_coils should be a positive integer")
-        self._n_coils = n_coils
+        self._n_coils = int(n_coils)

--- a/mri/operators/fourier/cartesian.py
+++ b/mri/operators/fourier/cartesian.py
@@ -17,12 +17,12 @@ import numpy as np
 import scipy as sp
 
 # Package import
-from ..base import OperatorBase
+from .base import FourierOperatorBase
 from .utils import convert_locations_to_mask, convert_mask_to_locations
 from modopt.interface.errors import warn
 
 
-class FFT(OperatorBase):
+class FFT(FourierOperatorBase):
     """ Standard unitary ND Fast Fourier Transform (FFT) class.
     The FFT will be normalized in a symmetric way. Here, ND = 2D or 3D.
 

--- a/mri/operators/fourier/non_cartesian.py
+++ b/mri/operators/fourier/non_cartesian.py
@@ -16,7 +16,7 @@ import warnings
 import numpy as np
 
 # Package import
-from ..base import OperatorBase
+from ..base import FourierOperatorBase
 from .utils import normalize_frequency_locations, get_stacks_fourier
 from modopt.interface.errors import warn
 
@@ -297,7 +297,7 @@ class gpuNUFFT:
         return np.squeeze(image)
 
 
-class NonCartesianFFT(OperatorBase):
+class NonCartesianFFT(FourierOperatorBase):
     """This class wraps around different implementation algorithms for NFFT"""
     def __init__(self, samples, shape, implementation='cpu', n_coils=1,
                  density_comp=None, **kwargs):
@@ -384,8 +384,15 @@ class NonCartesianFFT(OperatorBase):
         else:
             return self.impl.adj_op(coeffs, *args)
 
+    @property
+    def uses_sense(self):
+        """Return True if the Fourier Operator uses the SENSE method."""
+        try:
+            return self.impl.uses_sense
+        except AttributeError:
+            return False
 
-class Stacked3DNFFT(OperatorBase):
+class Stacked3DNFFT(FourierOperatorBase):
     """"  3-D non uniform Fast Fourier Transform class,
     fast implementation for Stacked samples. Note that the kspace locations
     must be in the form of a stack along z, with same locations in

--- a/mri/operators/fourier/non_cartesian.py
+++ b/mri/operators/fourier/non_cartesian.py
@@ -16,7 +16,7 @@ import warnings
 import numpy as np
 
 # Package import
-from ..base import FourierOperatorBase
+from .base import FourierOperatorBase
 from .utils import normalize_frequency_locations, get_stacks_fourier
 from modopt.interface.errors import warn
 

--- a/mri/operators/fourier/online.py
+++ b/mri/operators/fourier/online.py
@@ -3,7 +3,7 @@
 import numpy as np
 import scipy as sp
 
-from mri.operators.base import FourierOperatorBase
+from .base import FourierOperatorBase
 
 
 class ColumnFFT(FourierOperatorBase):

--- a/mri/operators/fourier/online.py
+++ b/mri/operators/fourier/online.py
@@ -3,10 +3,10 @@
 import numpy as np
 import scipy as sp
 
-from mri.operators.base import OperatorBase
+from mri.operators.base import FourierOperatorBase
 
 
-class ColumnFFT(OperatorBase):
+class ColumnFFT(FourierOperatorBase):
     """
     Fourier operator optimized to compute the 2D FFT + selection of various line of the kspace.
 

--- a/mri/operators/fourier/utils/processing.py
+++ b/mri/operators/fourier/utils/processing.py
@@ -312,31 +312,6 @@ def gridded_inverse_fourier_transform_stack(kspace_data_sorted,
     return np.swapaxes(np.fft.fftshift(np.fft.ifftn(np.fft.ifftshift(
         gridded_kspace))), 0, 1)
 
-
-def check_if_fourier_op_uses_sense(fourier_op):
-    """Utils function to check if fourier operator uses SENSE recon
-
-    Parameters
-    ----------
-
-    fourier_op: object of class FFT, NonCartesianFFT or Stacked3DNFFT in
-    mri.operators
-        the fourier operator for which we want to check if SENSE is
-        supported
-
-    Returns
-    -------
-    bool
-        True if SENSE recon is being used
-    """
-    from ..non_cartesian import NonCartesianFFT, gpuNUFFT
-    if isinstance(fourier_op, NonCartesianFFT) and \
-            isinstance(fourier_op.impl, gpuNUFFT):
-        return fourier_op.impl.uses_sense
-    else:
-        return False
-
-
 def estimate_density_compensation(kspace_loc, volume_shape, num_iterations=10):
     """ Utils function to obtain the density compensator for a
     given set of kspace locations.

--- a/mri/operators/gradient/base.py
+++ b/mri/operators/gradient/base.py
@@ -42,7 +42,7 @@ class GradBaseMRI(GradBasic):
     """
 
     def __init__(self, operator, trans_operator, shape,
-                 lips_calc_max_iter=10, lipschitz_cst=None, num_check_lips=10,
+                 lips_calc_max_iter=10, lipschitz_cst=None, dtype=np.complex64, num_check_lips=10,
                  verbose=0):
         # Initialize the GradBase with dummy data
         super(GradBaseMRI, self).__init__(
@@ -55,7 +55,8 @@ class GradBaseMRI(GradBasic):
             self.inv_spec_rad = 1.0 / self.spec_rad
         else:
             calc_lips = PowerMethod(self.trans_op_op, shape,
-                                    data_type=np.complex, auto_run=False)
+                                    data_type=dtype,
+                                    auto_run=False)
             calc_lips.get_spec_rad(extra_factor=1.1,
                                    max_iter=lips_calc_max_iter)
             self.spec_rad = calc_lips.spec_rad
@@ -65,6 +66,7 @@ class GradBaseMRI(GradBasic):
         if num_check_lips > 0:
             is_lips = check_lipschitz_cst(f=self.trans_op_op,
                                           x_shape=shape,
+                                          x_dtype=dtype,
                                           lipschitz_cst=self.spec_rad,
                                           max_nb_of_iter=num_check_lips)
             if not is_lips:

--- a/mri/operators/gradient/gradient.py
+++ b/mri/operators/gradient/gradient.py
@@ -32,7 +32,7 @@ class GradAnalysis(GradBaseMRI):
         Debug verbosity. Prints debug information during initialization if 1.
     """
     def __init__(self, fourier_op, verbose=0, **kwargs):
-        if fourier_op.n_coils != 1:
+        if fourier_op.n_coils != 1 and not fourier_op.uses_sense:
             data_shape = (fourier_op.n_coils, *fourier_op.shape)
         else:
             data_shape = fourier_op.shape

--- a/mri/operators/gradient/utils.py
+++ b/mri/operators/gradient/utils.py
@@ -20,7 +20,7 @@ This module contains all the utils tools needed in the p_MRI reconstruction.
 import numpy as np
 
 
-def check_lipschitz_cst(f, x_shape, lipschitz_cst, max_nb_of_iter=10):
+def check_lipschitz_cst(f, x_shape, lipschitz_cst, max_nb_of_iter=10, x_dtype=np.float64):
     """
     This methods check that for random entrees the lipschitz constraint are
     statisfied:
@@ -49,8 +49,8 @@ def check_lipschitz_cst(f, x_shape, lipschitz_cst, max_nb_of_iter=10):
 
     while is_lips_cst and n < max_nb_of_iter:
         n += 1
-        x = np.random.randn(*x_shape)
-        y = np.random.randn(*x_shape)
+        x = np.random.randn(*x_shape).astype(x_dtype)
+        y = np.random.randn(*x_shape).astype(x_dtype)
         is_lips_cst = (np.linalg.norm(f(x)-f(y)) <= (lipschitz_cst *
                                                      np.linalg.norm(x-y)))
 

--- a/mri/operators/utils/__init__.py
+++ b/mri/operators/utils/__init__.py
@@ -14,7 +14,7 @@ from ..fourier.utils import convert_mask_to_locations, \
     convert_locations_to_mask, normalize_frequency_locations, \
     discard_frequency_outliers, get_stacks_fourier, \
     gridded_inverse_fourier_transform_nd, \
-    gridded_inverse_fourier_transform_stack, check_if_fourier_op_uses_sense
+    gridded_inverse_fourier_transform_stack
 from ..linear.utils import extract_patches_from_2d_images, min_max_normalize, \
     learn_dictionary
 from ..gradient.utils import check_lipschitz_cst

--- a/mri/reconstructors/self_calibrating.py
+++ b/mri/reconstructors/self_calibrating.py
@@ -203,8 +203,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
                           "not found, re-calculating Smaps and "
                           "initializing gradient anyway!")
             recompute_smaps = True
-        if recompute_smaps and \
-                not check_if_fourier_op_uses_sense(self.fourier_op):
+        if recompute_smaps and not self.fourier_op.uses_sense:
             # Extract Sensitivity maps and initialize gradient
             smaps, _ = get_Smaps(
                 k_space=kspace_data,

--- a/mri/reconstructors/self_calibrating.py
+++ b/mri/reconstructors/self_calibrating.py
@@ -17,7 +17,6 @@ import warnings
 from .base import ReconstructorBase
 from ..operators import GradSelfCalibrationSynthesis, \
     GradSelfCalibrationAnalysis, GradAnalysis, GradSynthesis, WaveletN
-from ..operators.utils import check_if_fourier_op_uses_sense
 from ..operators.fourier.non_cartesian import gpuNUFFT
 from .utils.extract_sensitivity_maps import get_Smaps
 
@@ -118,12 +117,12 @@ class SelfCalibrationReconstructor(ReconstructorBase):
             raise ValueError("The value of n_coils for linear operation must "
                              "be 1 for Self-Calibrating reconstruction!")
         if gradient_formulation == 'analysis':
-            if check_if_fourier_op_uses_sense(fourier_op):
+            if fourier_op.uses_sense:
                 grad_class = GradAnalysis
             else:
                 grad_class = GradSelfCalibrationAnalysis
         elif gradient_formulation == 'synthesis':
-            if check_if_fourier_op_uses_sense(fourier_op):
+            if fourier_op.uses_sense:
                 grad_class = GradSynthesis
             else:
                 grad_class = GradSelfCalibrationSynthesis
@@ -147,7 +146,7 @@ class SelfCalibrationReconstructor(ReconstructorBase):
                              "sensitivity information is not aligned with" +
                              " the input dimension")
         self.n_jobs = n_jobs
-        if check_if_fourier_op_uses_sense(fourier_op):
+        if fourier_op.uses_sense:
             self.initialize_gradient_op(**self.extra_grad_args)
 
     def get_smaps(self):

--- a/mri/reconstructors/single_channel.py
+++ b/mri/reconstructors/single_channel.py
@@ -72,7 +72,7 @@ class SingleChannelReconstructor(ReconstructorBase):
                 nb_scale=3,
                 verbose=bool(verbose >= 30),
             )
-        if fourier_op.n_coils != 1 or linear_op.n_coils != 1:
+        if fourier_op.n_coils != 1 and  not fourier_op.uses_sense or linear_op.n_coils != 1:
             raise ValueError("The value of n_coils cannot be greater than 1 "
                              "for single channel reconstruction")
         if gradient_formulation == 'analysis':


### PR DESCRIPTION
This PR creates a BaseFourierClass, which represent the minimal interface every Fourier Operator of pysap-mri should have: 
- an `adj_op` method
- an `op` method
- an `uses_sense` attribute/property 
- `n_coils` and `shape` attributes

This Make all the Fourier operator of pysap-mri inherit this class. 

Bonus: This make the `SingleChannelReconstructor` able to reconstruct using SENSE, if the fourier operator can do it. 