### PR TITLE
Auto threshold 

### DIFF
--- a/doc/refs.bib
+++ b/doc/refs.bib
@@ -42,3 +42,16 @@
   year={1999},
   volume={42},
 }
+@inproceedings{Donoho1994,
+  address         = {Baltimore, MD, USA},
+  title           = {Threshold selection for wavelet shrinkage of noisy data},
+  ISBN            = {978-0-7803-2050-5},
+  url             = {http://ieeexplore.ieee.org/document/412133/},
+  DOI             = {10.1109/IEMBS.1994.412133},
+  booktitle       = {Proceedings of 16th Annual International Conference of the
+                  IEEE Engineering in Medicine and Biology Society},
+  publisher       = {IEEE},
+  author          = {Donoho, D.L. and Johnstone, I.M.},
+  year            = 1994,
+  pages           = {A24–A25}
+}

--- a/examples/cartesian_reconstruction_auto_threshold.py
+++ b/examples/cartesian_reconstruction_auto_threshold.py
@@ -82,7 +82,8 @@ coeffs = linear_op.op(image_rec0)
 # A single threshold is then also estimated for each scale.
 
 regularizer_op = AutoWeightedSparseThreshold(
-    coeffs.shape, linear=Identity(),
+    coeffs_shape=coeffs.shape,
+    linear=Identity(),
     update_period=5,
     sigma_range="global",
     tresh_range="scale",

--- a/examples/cartesian_reconstruction_auto_threshold.py
+++ b/examples/cartesian_reconstruction_auto_threshold.py
@@ -86,7 +86,7 @@ regularizer_op = AutoWeightedSparseThreshold(
     linear=Identity(),
     update_period=5,
     sigma_range="global",
-    tresh_range="scale",
+    thresh_range="scale",
     threshold_estimation="sure",
     thresh_type="soft"
 )

--- a/examples/cartesian_reconstruction_auto_threshold.py
+++ b/examples/cartesian_reconstruction_auto_threshold.py
@@ -1,97 +1,72 @@
-"""
-Neuroimaging Cartesian reconstruction
-=====================================
+#!/usr/bin/env python
+# coding: utf-8
 
-Author: Pierre-Antoine Comby / Chaithya G R
+# 
+# Neuroimaging cartesian reconstruction
+# =====================================
+# 
+# Author: Chaithya G R / Pierre-Antoine Comby
+# 
+# In this tutorial we will reconstruct an MRI image from the sparse kspace
+# measurements.
+# 
+# Import neuroimaging data
+# ------------------------
+# 
+# We use the toy datasets available in pysap, more specifically a 2D brain slice
+# and the cartesian acquisition scheme.
+# 
 
-In this tutorial we will reconstruct an MR image from the sparse k-space
-measurements.
+# In[1]:
 
-Moreover we will see the benefit of automating the  tuning of the regularisation parameters.
 
-Import neuroimaging data
-------------------------
-
-We use the toy datasets available in pysap, more specifically a 2D brain slice
-and the Cartesian acquisition scheme.
-"""
-
-# Package import
-from mri.operators import FFT, WaveletN
-from mri.operators.utils import convert_mask_to_locations
-from mri.reconstructors import SingleChannelReconstructor
-from mri.operators.proximity.weighted import AutoWeightedSparseThreshold
-import pysap
-from pysap.data import get_sample_data
-
+import matplotlib.pyplot as plt
+import numpy as np
+from modopt.math.metrics import snr, ssim
+from modopt.opt.linear import Identity
 # Third party import
 from modopt.opt.proximity import SparseThreshold
-from modopt.opt.linear import Identity
-from modopt.math.metrics import ssim
-import numpy as np
+from mri.operators import FFT, WaveletN
+from mri.operators.proximity.weighted import AutoWeightedSparseThreshold
+from mri.operators.utils import convert_mask_to_locations
+from mri.reconstructors import SingleChannelReconstructor
+from pysap.data import get_sample_data
 
-# Loading input data
 image = get_sample_data('2d-mri')
-
-# Obtain k-space Cartesian Mask
+print(image.data.min(), image.data.max())
+image = image.data
+image /= np.max(image)
 mask = get_sample_data("cartesian-mri-mask")
-
-# View Input
-# image.show()
-# mask.show()
-
-#%%
-# Generate the kspace
-# -------------------
-#
-# From the 2D brain slice and the sampling mask, we retrospectively
-# undersample the k-space using a Cartesian acquisition mask
-# We then reconstruct the zero order solution as a baseline
 
 
 # Get the locations of the kspace samples
 kspace_loc = convert_mask_to_locations(mask.data)
 # Generate the subsampled kspace
-fourier_op = FFT(samples=kspace_loc, shape=image.shape)
+fourier_op = FFT(mask=mask, shape=image.shape)
 kspace_data = fourier_op.op(image)
 
-# Zero filled solution
-image_rec0 = pysap.Image(data=fourier_op.adj_op(kspace_data),
-                         metadata=image.metadata)
-# image_rec0.show()
+# Zero order solution
+image_rec0 = np.abs(fourier_op.adj_op(kspace_data))
 
 # Calculate SSIM
 base_ssim = ssim(image_rec0, image)
 print(base_ssim)
 
 #%%
-# FISTA optimization
+# POGM optimization
 # ------------------
-#
-# We now want to refine the zero order solution by computing the Compressed sensing one,
-# using FISTA optimization.
+# We now want to refine the zero order solution using an accelerated Proximal Gradient
+# Descent algorithm (FISTA or POGM).
 # The cost function is set to Proximity Cost + Gradient Cost
 
+# In[4]:
+
+
 # Setup the operators
-linear_op = WaveletN(wavelet_name="sym8", nb_scales=4)
-coeffs = linear_op.op(image_rec0)
+linear_op = WaveletN(wavelet_name="sym8", nb_scales=3)
 
-#%%
-# the auto estimation of the threshold uses the methods of :cite:`donoho1994`.
-# The noise standard deviation is estimated on the largest scale using the detail (HH) band.
-# A single threshold is then also estimated for each scale.
-
-regularizer_op = AutoWeightedSparseThreshold(
-    coeffs_shape=coeffs.shape,
-    linear=Identity(),
-    update_period=5,
-    sigma_range="global",
-    thresh_range="scale",
-    threshold_estimation="sure",
-    thresh_type="soft"
-)
-#%% The rest of the setup is similar to classical example.
-
+# Manual tweak of the regularisation parameter
+regularizer_op = SparseThreshold(Identity(), 2e-3, thresh_type="soft")
 # Setup Reconstructor
 reconstructor = SingleChannelReconstructor(
     fourier_op=fourier_op,
@@ -100,16 +75,151 @@ reconstructor = SingleChannelReconstructor(
     gradient_formulation='synthesis',
     verbose=1,
 )
-
-#%%
-#  With everythiing setup we can start Reconstruction
+# Start Reconstruction
 x_final, costs, metrics = reconstructor.reconstruct(
     kspace_data=kspace_data,
-    optimization_alg='fista',
-    num_iterations=200,
+    optimization_alg='pogm',
+    num_iterations=100,
+    cost_op_kwargs={"cost_interval":None},
+    metric_call_period=1,
+    metrics = {
+        "snr":{
+            "metric": snr,
+            "mapping": {"x_new":"test"},
+            "cst_kwargs": {"ref": image},
+            "early_stopping":False,
+        },
+        "ssim":{
+            "metric": ssim,
+            "mapping": {"x_new":"test"},
+            "cst_kwargs": {"ref": image},
+            "early_stopping": False,
+        }
+    }
 )
-image_rec = pysap.Image(data=np.abs(x_final))
+
+image_rec = np.abs(x_final)
 # image_rec.show()
 # Calculate SSIM
 recon_ssim = ssim(image_rec, image)
+recon_snr= snr(image_rec, image)
+
 print('The Reconstruction SSIM is : ' + str(recon_ssim))
+print('The Reconstruction SNR is : ' + str(recon_snr))
+
+#%%
+# Threshold estimation using SURE 
+# -------------------------------
+
+_w = None
+
+def static_weight(w, idx):
+    print(np.unique(w))
+    return w
+
+# Setup the operators
+linear_op = WaveletN(wavelet_name="sym8", nb_scale=3,padding_mode="periodization")
+coeffs = linear_op.op(image_rec0)
+print(linear_op.coeffs_shape)
+
+# Here we don't manually setup the regularisation weights, but use statistics on the wavelet details coefficients
+
+regularizer_op = AutoWeightedSparseThreshold(
+    linear_op.coeffs_shape, linear=Identity(),
+    update_period=0, # the weight is updated only once.
+    sigma_range="global",
+    thresh_range="global",
+    threshold_estimation="sure",
+    thresh_type="soft",
+)
+# Setup Reconstructor
+reconstructor = SingleChannelReconstructor(
+    fourier_op=fourier_op,
+    linear_op=linear_op,
+    regularizer_op=regularizer_op,
+    gradient_formulation='synthesis',
+    verbose=1,
+)
+# Start Reconstruction
+x_final, costs, metrics2 = reconstructor.reconstruct(
+    kspace_data=kspace_data,
+    optimization_alg='pogm',
+    num_iterations=100,
+    metric_call_period=1,
+    cost_op_kwargs={"cost_interval":None},
+    metrics = {
+         "snr":{
+            "metric": snr,
+            "mapping": {"x_new":"test"},
+            "cst_kwargs": {"ref": image},
+            "early_stopping":False,
+        },
+        "ssim":{
+            "metric": ssim,
+            "mapping": {"x_new":"test"},
+            "cst_kwargs": {"ref": image},
+            "early_stopping": False,
+        },
+        "cost_grad":{
+            "metric": lambda x: reconstructor.gradient_op.cost(linear_op.op(x)),
+            "mapping": {"x_new":"x"},
+            "cst_kwargs": {},
+            "early_stopping": False,
+        },
+        "cost_prox":{
+            "metric": lambda x: reconstructor.prox_op.cost(linear_op.op(x)),
+            "mapping": {"x_new":"x"},
+            "cst_kwargs": {},
+            "early_stopping": False,
+        }
+    }
+)
+image_rec2 = np.abs(x_final)
+# image_rec.show()
+# Calculate SSIM
+recon_ssim2 = ssim(image_rec2, image)
+recon_snr2 = snr(image_rec2, image)
+
+print('The Reconstruction SSIM is : ' + str(recon_ssim2))
+print('The Reconstruction SNR is : ' + str(recon_snr2))
+
+plt.subplot(121)
+plt.plot(metrics["snr"]["time"], metrics["snr"]["values"], label="pogm classic")
+plt.plot(metrics2["snr"]["time"], metrics2["snr"]["values"], label="pogm sure global")
+plt.ylabel("snr")
+plt.xlabel("time")
+plt.legend()
+plt.subplot(122)
+plt.plot(metrics["ssim"]["time"], metrics["ssim"]["values"])
+plt.plot(metrics2["ssim"]["time"], metrics2["ssim"]["values"])
+plt.ylabel("ssim")
+plt.xlabel("time")
+plt.figure()
+plt.subplot(121)
+plt.plot(metrics["snr"]["index"], metrics["snr"]["values"])
+plt.plot(metrics2["snr"]["index"], metrics2["snr"]["values"])
+plt.ylabel("snr")
+plt.subplot(122)
+plt.plot(metrics["ssim"]["index"], metrics["ssim"]["values"])
+plt.plot(metrics2["ssim"]["index"], metrics2["ssim"]["values"])
+
+
+#%%
+# Qualitative results
+# -------------------
+#
+def my_imshow(ax, img, title):
+    ax.imshow(img, cmap="gray")
+    ax.set_title(title)
+    ax.axis("off")
+            
+
+
+fig, axs = plt.subplots(2,2)
+
+my_imshow(axs[0,0], image, "Ground Truth")
+my_imshow(axs[0,1], abs(image_rec0), f"Zero Order \n SSIM={base_ssim:.4f}")
+my_imshow(axs[1,0], abs(image_rec), f"Fista Classic \n SSIM={recon_ssim:.4f}")
+my_imshow(axs[1,1], abs(image_rec2), f"Fista Sure \n SSIM={recon_ssim2:.4f}")
+
+fig.tight_layout()

--- a/examples/cartesian_reconstruction_auto_threshold.py
+++ b/examples/cartesian_reconstruction_auto_threshold.py
@@ -1,0 +1,101 @@
+"""
+Neuroimaging cartesian reconstruction
+=====================================
+
+Author: Pierre-Antoine Comby / Chaithya G R
+
+In this tutorial we will reconstruct an MRI image from the sparse kspace
+measurements.
+Moreover we will see the benefit of automatic tuning of the regularisation parameters.
+
+Import neuroimaging data
+------------------------
+
+We use the toy datasets available in pysap, more specifically a 2D brain slice
+and the cartesian acquisition scheme.
+"""
+
+# Package import
+from mri.operators import FFT, WaveletN
+from mri.operators.utils import convert_mask_to_locations
+from mri.reconstructors import SingleChannelReconstructor
+from mri.operators.proximity.weighted import AutoWeightedSparseThreshold
+import pysap
+from pysap.data import get_sample_data
+
+# Third party import
+from modopt.opt.proximity import SparseThreshold
+from modopt.opt.linear import Identity
+from modopt.math.metrics import ssim
+import numpy as np
+
+# Loading input data
+image = get_sample_data('2d-mri')
+
+# Obtain K-Space Cartesian Mask
+mask = get_sample_data("cartesian-mri-mask")
+
+# View Input
+# image.show()
+# mask.show()
+
+#%%
+# Generate the kspace
+# -------------------
+#
+# From the 2D brain slice and the acquisition mask, we retrospectively
+# undersample the k-space using a cartesian acquisition mask
+# We then reconstruct the zero order solution as a baseline
+
+
+# Get the locations of the kspace samples
+kspace_loc = convert_mask_to_locations(mask.data)
+# Generate the subsampled kspace
+fourier_op = FFT(samples=kspace_loc, shape=image.shape)
+kspace_data = fourier_op.op(image)
+
+# Zero order solution
+image_rec0 = pysap.Image(data=fourier_op.adj_op(kspace_data),
+                         metadata=image.metadata)
+# image_rec0.show()
+
+# Calculate SSIM
+base_ssim = ssim(image_rec0, image)
+print(base_ssim)
+
+#%%
+# FISTA optimization
+# ------------------
+#
+# We now want to refine the zero order solution using a FISTA optimization.
+# The cost function is set to Proximity Cost + Gradient Cost
+
+# Setup the operators
+linear_op = WaveletN(wavelet_name="sym8", nb_scales=4)
+coeffs = linear_op.op(image_rec0)
+regularizer_op = AutoWeightedSparseThreshold(
+    coeffs.shape, linear=Identity(),
+    update_period=5,
+    sigma_estimation="global",
+    threshold_estimation="sure",
+    thresh_type="soft"
+)
+# Setup Reconstructor
+reconstructor = SingleChannelReconstructor(
+    fourier_op=fourier_op,
+    linear_op=linear_op,
+    regularizer_op=regularizer_op,
+    gradient_formulation='synthesis',
+    verbose=1,
+)
+# Start Reconstruction
+x_final, costs, metrics = reconstructor.reconstruct(
+    kspace_data=kspace_data,
+    optimization_alg='fista',
+    num_iterations=200,
+)
+image_rec = pysap.Image(data=np.abs(x_final))
+# image_rec.show()
+# Calculate SSIM
+recon_ssim = ssim(image_rec, image)
+print('The Reconstruction SSIM is : ' + str(recon_ssim))

--- a/examples/cartesian_reconstruction_auto_threshold.py
+++ b/examples/cartesian_reconstruction_auto_threshold.py
@@ -34,7 +34,7 @@ import numpy as np
 image = get_sample_data('2d-mri')
 
 # Obtain k-space Cartesian Mask
-mask = get_sample_data("Cartesian-mri-mask")
+mask = get_sample_data("cartesian-mri-mask")
 
 # View Input
 # image.show()

--- a/mri/operators/proximity/__init__.py
+++ b/mri/operators/proximity/__init__.py
@@ -6,3 +6,9 @@
 # http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html
 # for details.
 ##########################################################################
+
+from .weighted import AutoWeightedSparseThreshold, WeightedSparseThreshold
+from .ordered_weighted_l1_norm import OWL
+
+
+__all__ = ['AutoWeightedSparseThreshold', 'WeightedSparseThreshold', 'OWL',]

--- a/mri/operators/proximity/weighted.py
+++ b/mri/operators/proximity/weighted.py
@@ -158,15 +158,20 @@ def _thresh_select(data, thresh_est):
 
     if thresh_est == "sure":
         thr = _sure_est(data)
-    if thresh_est == "universal":
+    elif thresh_est == "universal":
         thr = universal_thr
-    if thresh_est == "hybrid-sure":
+    elif thresh_est == "hybrid-sure":
         eta = np.sum(data ** 2) /n  - 1
         if eta < (np.log2(n) ** 1.5) / np.sqrt(n):
             thr = universal_thr
         else:
             test_th = _sure_est(data)
             thr = min(test_th, universal_thr)
+    else:
+        raise ValueError(
+            "Unsupported threshold method."
+            "Available are 'sure', 'universal' and 'hybrid-sure'"
+        )
     return thr
 
 def wavelet_noise_estimate(wavelet_coeffs, coeffs_shape, sigma_est):
@@ -209,13 +214,13 @@ def wavelet_noise_estimate(wavelet_coeffs, coeffs_shape, sigma_est):
     stop = 0
     if sigma_est is None:
         return sigma_ret
-    if sigma_est == "band":
+    elif sigma_est == "band":
         for i in range(1, len(coeffs_shape)):
             stop += np.prod(coeffs_shape[i])
             sigma_ret[i] = _sigma_mad(wavelet_coeffs[start:stop])
             start = stop
-    if sigma_est == "level":
-        # use the diagonal coefficient to estimate the variance of the level.
+    elif sigma_est == "level":
+        # use the diagonal coefficients subband to estimate the variance of the level.
         # it assumes that the band of the same level have the same shape.
         start = np.prod(coeffs_shape[0])
         for i, scale_shape in enumerate(np.unique(coeffs_shape[1:], axis=0)):
@@ -226,7 +231,7 @@ def wavelet_noise_estimate(wavelet_coeffs, coeffs_shape, sigma_est):
             stop = start + scale_sz * bpl
             sigma_ret[1+i*(bpl):1+(i+1)*bpl] = _sigma_mad(wavelet_coeffs[start:stop])
             start = stop
-    if sigma_est == "global":
+    elif sigma_est == "global":
         sigma_ret *= _sigma_mad(wavelet_coeffs[-np.prod(coeffs_shape[-1]):])
     sigma_ret[0] = np.NaN
     return sigma_ret

--- a/mri/operators/proximity/weighted.py
+++ b/mri/operators/proximity/weighted.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy as sp
 
 from modopt.opt.proximity import SparseThreshold
 from modopt.opt.linear import Identity
@@ -78,3 +79,124 @@ class WeightedSparseThreshold(SparseThreshold):
         if self.zero_weight_coarse:
             weights_init[:np.prod(self.cf_shape[0])] = 0
         self.weights = weights_init
+
+
+class AutoWeightedSparseThreshold(WeightedSparseThreshold):
+    """This WeightedSparseThreshold uses the universal threshold rules to """
+    def __init__(self, coeffs_shape,  linear=Identity(), update_period=0,
+               sigma_estimation="global", threshold_estimation="sure", **kwargs):
+        self._n_op_calls = 0
+        self._sigma_estimation = sigma_estimation
+        self._update_period = update_period
+
+        self._thresh_estimation = threshold_estimation
+
+        weights_init = np.zeros(np.sum(np.prod(self.cf_shape, axis=-1)))
+        super().__init__(weights=weights_init,
+                         weight_type="scale_based",
+                         **kwargs)
+
+    def _auto_thresh_scale(self, input_data, sigma=None):
+        """Determine a threshold value adapted to denoise the data of a specific scale.
+
+        Parameters
+        ----------
+        input_data: numpy.ndarray
+            data that should be thresholded.
+        sigma: float
+            Estimation of the noise standard deviation.
+        Returns
+        -------
+        float
+            The estimated threshold.
+
+        Raises
+        ------
+            ValueError is method is not supported.
+        Notes
+        -----
+        The choice of the threshold makes the assumptions of a white additive gaussian noise.
+        """
+
+        #tmp = np.sort(input_data.flatten())
+        tmp = input_data.flatten()
+        # use the robust estimator to estimate the noise variance.
+        med = np.median(tmp)
+        if sigma is None:
+            sigma = np.median(np.abs(tmp-med)) / 0.6745
+        N = len(input_data)
+        j = np.log2(N)
+
+        uni_threshold = np.sqrt(2*np.log(N))
+
+        if self._thresh_estimation == "universal":
+            return sigma * uni_threshold, sigma
+        elif self._thresh_estimation == "sure":
+            tmp = tmp **2
+            eps2 = (sigma ** 2) /N
+            # TODO: optimize the estimation
+            def _sure(t):
+                e2t2 = eps2 * (t**2)
+                return (N * eps2
+                   + np.sum(np.minimum(tmp, e2t2))
+                   - 2*eps2*np.sum(tmp <= e2t2)
+                )
+
+            thresh = sp.optimize.minimize_scalar(
+                _sure,
+                method="bounded",
+                bounds=[0, uni_threshold]).x
+            sj2 = np.sum(tmp/eps2 - 1)/N
+            if sj2 >= 3*j/np.sqrt(2*N):
+                return thresh, sigma
+            else:
+                return uni_threshold, sigma
+
+        else:
+            raise ValueError("Unknown method name")
+
+    def _auto_thresh(self, input_data):
+        """Determines the threshold for every scale (except the coarse one) using the provided method.
+
+        Parameters
+        ----------
+        input_data: list of numpy.ndarray
+
+        Returns
+        -------
+        thresh_list: list
+            list of threshold for every scale
+        """
+        sigma = None
+        thresh_list = []
+        for band_idx in range(len(input_data)-1, 1, -1):
+            thresh_value, sigma_est = self._auto_thresh_scale(input_data[band_idx], sigma=sigma)
+            if self._sigma_estimation == "global" and band_idx == len(input_data)-1:
+                sigma = sigma_est
+            thresh_list.append(thresh_value)
+        return thresh_list
+
+
+    def _op_method(self, input_data, extra_factor=1.0):
+        """Operator.
+
+        This method returns the input data thresholded by the weights.
+        The weights are computed using the universal threshold rule.
+
+        Parameters
+        ----------
+        input_data : numpy.ndarray
+            Input data array
+        extra_factor : float
+            Additional multiplication factor (default is ``1.0``)
+
+        Returns
+        -------
+        numpy.ndarray
+            Thresholded data
+
+        """
+        if (self._update_period == 0 and self._n_op_calls == 0) or (self._n_op_calls % self._update_period == 0) :
+            self.mu , sigma = self._auto_thresh(input_data)
+        self._n_op_calls += 1
+        return super()._op_method(input_data, extra_factor=extra_factor)

--- a/mri/operators/proximity/weighted.py
+++ b/mri/operators/proximity/weighted.py
@@ -185,7 +185,7 @@ def wavelet_noise_estimate(wavelet_coeffs, coeffs_shape, sigma_est):
         list of tuple representing the shape of each subband.
         Typically accessible by WaveletN.coeffs_shape
     sigma_est: str
-        Estimation method, available are "band", "level", and "global"
+        Estimation method, available are "band", "scale", and "global"
     Returns
     -------
     numpy.ndarray
@@ -201,7 +201,7 @@ def wavelet_noise_estimate(wavelet_coeffs, coeffs_shape, sigma_est):
     The variance estimation is either performed:
 
      - On each subband (``sigma_est = "band"``)
-     - On each level, using the detailled HH subband. (``sigma_est = "level"``)
+     - On each scale, using the detailled HH subband. (``sigma_est = "scale"``)
      - Only with the largest, most detailled HH band (``sigma_est = "global"``)
 
     See Also
@@ -219,9 +219,9 @@ def wavelet_noise_estimate(wavelet_coeffs, coeffs_shape, sigma_est):
             stop += np.prod(coeffs_shape[i])
             sigma_ret[i] = _sigma_mad(wavelet_coeffs[start:stop])
             start = stop
-    elif sigma_est == "level":
-        # use the diagonal coefficients subband to estimate the variance of the level.
-        # it assumes that the band of the same level have the same shape.
+    elif sigma_est == "scale":
+        # use the diagonal coefficients subband to estimate the variance of the scale.
+        # it assumes that the band of the same scale have the same shape.
         start = np.prod(coeffs_shape[0])
         for i, scale_shape in enumerate(np.unique(coeffs_shape[1:], axis=0)):
             scale_sz = np.prod(scale_shape)
@@ -256,10 +256,10 @@ def wavelet_threshold_estimate(
         Typically accessible by WaveletN.coeffs_shape
     thresh_range: str. default "global"
         Defines on which data range to estimate thresholds.
-        Either "band", "level", or "global"
+        Either "band", "scale", or "global"
     sigma_range: str, default "global"
         Defines on which data range to estimate thresholds.
-        Either "band", "level", or "global"
+        Either "band", "scale", or "global"
     thresh_estimation: str, default "hybrid-sure"
         Name of the threshold estimation method.
         Available are "sure", "hybrid-sure", "universal"
@@ -297,15 +297,15 @@ def wavelet_threshold_estimate(
             ts.append(t)
             weights[start:stop] = t
             start = stop
-    elif thresh_range == "level":
+    elif thresh_range == "scale":
         start = np.prod(coeffs_shape[0])
         start_hh = start
         for i, scale_shape in enumerate(np.unique(coeffs_shape[1:], axis=0)):
             scale_sz = np.prod(scale_shape)
             matched_bands = np.all(scale_shape == coeffs_shape[1:], axis=1)
-            band_per_level = np.sum(matched_bands)
-            start_hh = start + scale_sz * (band_per_level-1)
-            stop = start + scale_sz * band_per_level
+            band_per_scale = np.sum(matched_bands)
+            start_hh = start + scale_sz * (band_per_scale-1)
+            stop = start + scale_sz * band_per_scale
             t = sigma_bands[i+1] * _thresh_select(
                 wavelet_coeffs[start_hh:stop] / sigma_bands[i+1],
                 thresh_estimation
@@ -337,7 +337,7 @@ class AutoWeightedSparseThreshold(SparseThreshold):
     threshold_estimation: str
         threshold estimation method. Available are "sure", "hybrid-sure" and "universal"
     sigma_estimation: str
-        noise std estimation method. Available are "global", "level" and "band"
+        noise std estimation method. Available are "global", "scale" and "band"
     thresh_type: str
         "hard" or "soft" thresholding.
     """
@@ -352,9 +352,9 @@ class AutoWeightedSparseThreshold(SparseThreshold):
         self._update_period = update_period
 
 
-        if thresh_range not in ["bands", "level", "global"]:
+        if thresh_range not in ["bands", "scale", "global"]:
             raise ValueError("Unsupported threshold range.")
-        if sigma_range not in ["bands", "level", "global"]:
+        if sigma_range not in ["bands", "scale", "global"]:
             raise ValueError("Unsupported sigma estimation method.")
         if threshold_estimation not in ["sure", "hybrid-sure", "universal", "bayes"]:
             raise ValueError("Unsupported threshold estimation method.")

--- a/mri/operators/proximity/weighted.py
+++ b/mri/operators/proximity/weighted.py
@@ -336,8 +336,10 @@ class AutoWeightedSparseThreshold(SparseThreshold):
         Estimation of the weight update period.
     threshold_estimation: str
         threshold estimation method. Available are "sure", "hybrid-sure" and "universal"
-    sigma_estimation: str
-        noise std estimation method. Available are "global", "scale" and "band"
+    thresh_range: str
+        threshold range of estimation. Available are "global", "scale" and "band"
+    sigma_range: str
+        noise std range of estimation. Available are "global", "scale" and "band"
     thresh_type: str
         "hard" or "soft" thresholding.
     """

--- a/mri/operators/proximity/weighted.py
+++ b/mri/operators/proximity/weighted.py
@@ -179,14 +179,6 @@ def _wavelet_noise_estimate(wavelet_coefs, coeffs_shape, sigma_est):
             stop = start + scale_sz * band_per_level
             sigma_ret[1+i*(band_per_level):1+(i+1)*band_per_level] = _sigma_mad(wavelet_coefs[start:stop])
             start = stop
-    if sigma_est == "level-shared":
-        start = np.prod(coeffs_shape[0])
-        for i, scale_shape in enumerate(np.unique(coeffs_shape[1:], axis=0)):
-            scale_sz = np.prod(scale_shape)
-            band_per_level = np.sum(scale_shape == coeffs_shape)
-            stop = start + scale_sz * band_per_level
-            sigma_ret[i:i+band_per_level] = _sigma_mad(wavelet_coefs[start:stop])
-            start = stop
     if sigma_est == "global":
         sigma_ret *= _sigma_mad(wavelet_coefs[-np.prod(coeffs_shape[-1]):])
     sigma_ret[0] = np.NaN

--- a/mri/optimizers/forward_backward.py
+++ b/mri/optimizers/forward_backward.py
@@ -69,7 +69,7 @@ def fista(gradient_op, linear_op, prox_op, cost_op, kspace_generator=None, estim
     if x_init is None:
         x_init = np.squeeze(np.zeros((gradient_op.linear_op.n_coils,
                                       *gradient_op.fourier_op.shape),
-                                     dtype=np.complex))
+                                     dtype=np.complex64))
     alpha_init = linear_op.op(x_init)
 
     # Welcome message

--- a/mri/optimizers/primal_dual.py
+++ b/mri/optimizers/primal_dual.py
@@ -101,7 +101,7 @@ def condatvu(gradient_op, linear_op, dual_regularizer, cost_op, kspace_generator
     if x_init is None:
         x_init = np.squeeze(np.zeros((linear_op.n_coils,
                                       *gradient_op.fourier_op.shape),
-                                     dtype=np.complex))
+                                     dtype=np.complex64))
     primal = x_init
     dual = linear_op.op(primal)
     weights = dual

--- a/mri/optimizers/utils/cost.py
+++ b/mri/optimizers/utils/cost.py
@@ -152,7 +152,7 @@ class GenericCost(costObj):
             the cost function defined by the operators (gradient + prox_op).
         """
         if self.optimizer_type == 'forward_backward':
-            if not hasattr(self.grad_op, 'linear_op') and self.linear_op is not None:
+            if not hasattr(self.gradient_op, 'linear_op') and self.linear_op is not None:
                 y_new = self.linear_op.op(x_new)
             else:
                 # synthesis case, y_new is already in the linear_op (sparse) domain.


### PR DESCRIPTION
This PR implements auto-thresholding tuning for Proximal operator.

The main two function `wavelet_noise_estimation` and `wavelet_threshold_estimation` are operator independent, to let the user access them (and later fine tune the threshold if required). 

The estimation of threshold is done in 2 Step: 
 1. Estimate the noise variance on specific ranges (on every subband, on every level, or using a single global estimate )
 2. Compute a threshold for a specific ranges using one of the 3 following method: 
   - SURE
   - Hybrid-SURE
   - Universal threshold. 
 In total this make 9 auto-tuned configuration available. 

I also provide an example reconstruction script. 

I don't have much time to write good unittests for now, and IMO the test module should undergo the same refactoring I did for ModOpt. 